### PR TITLE
fix: cap license check at 200 repos — was unbounded causing CI timeout

### DIFF
--- a/src/enrichment.py
+++ b/src/enrichment.py
@@ -306,6 +306,7 @@ async def detect_license_changes(inventory: Dict) -> List[Dict]:
         log_event("[License] No repos with stored licenses to check")
         return []
 
+    candidates = candidates[:MAX_REPOS_DEFAULT]  # cap to same limit as activity enrichment
     log_event(f"[License] Checking {len(candidates)} repos for license changes")
 
     changes: List[Dict] = []


### PR DESCRIPTION
`detect_license_changes()` had no repo limit and was iterating all entries with `gh_license` set. Applies same `MAX_REPOS_DEFAULT=200` cap as activity enrichment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)