### PR TITLE
fix: NoneType crashes in v2_optimizer, dedup, and news_digest

### DIFF
--- a/src/dedup.py
+++ b/src/dedup.py
@@ -71,7 +71,7 @@ def find_title_duplicates(inventory: Dict, threshold: float = 0.85) -> List[Tupl
         norm = normalize_title(title)
         if len(norm) < 10:
             continue
-        entries.append((url, norm, entry.get("stars", 0)))
+        entries.append((url, norm, entry.get("stars") or 0))
 
     log_event(f"[Dedup] Building title index for {len(entries)} entries...")
 
@@ -105,7 +105,7 @@ def find_title_duplicates(inventory: Dict, threshold: float = 0.85) -> List[Tupl
 
 def _entry_score(entry: Dict) -> Tuple:
     return (
-        entry.get("stars", 0),
+        entry.get("stars") or 0,
         1 if entry.get("ai_summary") else 0,
         1 if entry.get("hierarchy") else 0,
         len(entry.get("tags", [])),

--- a/src/news_digest.py
+++ b/src/news_digest.py
@@ -319,8 +319,8 @@ class NewsDigestEngine:
             for cat_name, entries in category_pools.items():
                 entries.sort(
                     key=lambda x: (
-                        x.get("stars", 0),
-                        x.get("discovered_at", ""),
+                        x.get("stars") or 0,
+                        x.get("discovered_at") or "",
                     ),
                     reverse=True,
                 )

--- a/src/v2_optimizer.py
+++ b/src/v2_optimizer.py
@@ -629,7 +629,7 @@ class V2VisionEngine:
         # 1. GitHub Objective Reality (Mandate 43)
         raw_gh = item.get("gh_stars", 0)
         gh_stars = int(raw_gh) if str(raw_gh).isdigit() else 0
-        curator_stars = int(item.get("stars", 0))
+        curator_stars = int(item.get("stars") or 0)
 
         if gh_stars > 15000 or curator_stars >= 5: 
             tags.add("[DE FACTO STANDARD]")


### PR DESCRIPTION
Replace `.get('stars', 0)` with `.get('stars') or 0` in all modules where null values cause TypeError. Fixes CI crashes in v2_optimizer:632, dedup:74/108, news_digest:322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)