### PR TITLE
fix: None resource_type crash in _calculate_tags

### DIFF
--- a/src/v2_optimizer.py
+++ b/src/v2_optimizer.py
@@ -639,7 +639,7 @@ class V2VisionEngine:
             if "[COMMUNITY-TOOL]" in tags: tags.remove("[COMMUNITY-TOOL]")
         
         # 2. Type Mapping (AI based labels)
-        res_type = item.get("resource_type", "Reference").lower()
+        res_type = (item.get("resource_type") or "Reference").lower()
         if any(x in res_type for x in ["guide", "tutorial", "hands-on", "learning", "course"]): 
             tags.add("[GUIDE]")
         if any(x in res_type for x in ["case study", "report", "whitepaper", "success story", "usage"]): 


### PR DESCRIPTION
Guards `item.get('resource_type') or 'Reference'` — same pattern as the stars/None fixes in v2.6.9.