### PR TITLE
feat: cache news_digest.json by date, skip Gemini on same-day re-runs

### DIFF
--- a/.github/workflows/04.1.agentic_v2_publish.yml
+++ b/.github/workflows/04.1.agentic_v2_publish.yml
@@ -60,7 +60,20 @@ jobs:
       - name: Installation of Dependencies
         run: |
           pip install --no-cache-dir pydantic PyGithub httpx fake-useragent pytz python-dotenv pyyaml tenacity
-          
+
+      - name: Get current date for digest cache key
+        id: digest-date
+        run: echo "date=$(date -u +%Y-%m-%d)" >> $GITHUB_OUTPUT
+
+      - name: Restore News Digest Cache
+        id: cache-digest
+        uses: actions/cache/restore@v5
+        with:
+          path: data/news_digest.json
+          key: news-digest-${{ steps.digest-date.outputs.date }}
+          restore-keys: |
+            news-digest-
+
       - name: Execute Video Portal Generator
         env:
           PYTHONPATH: ${{ github.workspace }}
@@ -87,13 +100,26 @@ jobs:
           python -u -m src.enrichment || echo "Enrichment pipeline skipped (no token or error)"
 
       - name: Generate News Digest
+        if: steps.cache-digest.outputs.cache-hit != 'true'
         env:
           PYTHONPATH: ${{ github.workspace }}
           GEMINI_API_KEY_1: ${{ secrets.GEMINI_API_KEY_1 }}
           GEMINI_API_KEY_2: ${{ secrets.GEMINI_API_KEY_2 }}
         run: |
           python -u -m src.news_digest || echo "News digest generation skipped (no API key or error)"
+
+      - name: Generate RSS Feed
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
           python -u -m src.rss_generator || echo "RSS generation skipped"
+
+      - name: Save News Digest Cache
+        if: steps.cache-digest.outputs.cache-hit != 'true' && hashFiles('data/news_digest.json') != ''
+        uses: actions/cache/save@v5
+        with:
+          path: data/news_digest.json
+          key: news-digest-${{ steps.digest-date.outputs.date }}
 
       - name: Run V2 Publisher (Render-Only)
         env:

--- a/.github/workflows/09.weekly_digest.yml
+++ b/.github/workflows/09.weekly_digest.yml
@@ -33,13 +33,39 @@ jobs:
       - name: Install Dependencies
         run: pip install -r requirements.txt
 
+      - name: Get current date for digest cache key
+        id: digest-date
+        run: echo "date=$(date -u +%Y-%m-%d)" >> $GITHUB_OUTPUT
+
+      - name: Restore News Digest Cache
+        id: cache-digest
+        uses: actions/cache/restore@v5
+        with:
+          path: data/news_digest.json
+          key: news-digest-${{ steps.digest-date.outputs.date }}
+          restore-keys: |
+            news-digest-
+
       - name: Generate News Digest (Gemini)
+        if: steps.cache-digest.outputs.cache-hit != 'true'
         env:
           PYTHONPATH: ${{ github.workspace }}
           GEMINI_API_KEY_1: ${{ secrets.GEMINI_API_KEY_1 }}
           GEMINI_API_KEY_2: ${{ secrets.GEMINI_API_KEY_2 }}
         run: |
           python -u -m src.news_digest
+
+      - name: Save News Digest Cache
+        if: steps.cache-digest.outputs.cache-hit != 'true' && hashFiles('data/news_digest.json') != ''
+        uses: actions/cache/save@v5
+        with:
+          path: data/news_digest.json
+          key: news-digest-${{ steps.digest-date.outputs.date }}
+
+      - name: Generate RSS Feed
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
           python -u -m src.rss_generator || echo "RSS generation skipped"
 
       - name: Render V2 Portal (Digest Pages Only)


### PR DESCRIPTION
Restore/save cache around digest step with key `news-digest-YYYY-MM-DD`. Re-runs on same day skip Gemini (~20min + credits saved).