### PR TITLE
fix: remove content-visibility from dense indexes (v2.9.2)

### DIFF
--- a/docs/static/v2_elite.css
+++ b/docs/static/v2_elite.css
@@ -876,18 +876,13 @@ a {
 /* PERFORMANCE OPTIMIZATIONS FOR DENSE INDEXES          */
 /* ---------------------------------------------------- */
 
-/* Defer rendering of heavy tag sections on the tags index page */
-.v2-tag-section {
-  content-visibility: auto;
-  contain-intrinsic-size: auto 500px;
-}
-
-/* Defer rendering of large resource lists in category pages */
-.md-typeset > ul,
-.md-typeset > ol {
-  content-visibility: auto;
-  contain-intrinsic-size: auto 200px;
-}
+/* NOTE: `content-visibility: auto` was removed here (v2.9.2). It deferred
+   painting of off-screen <ul>/<ol> lists, which on the dark (slate) theme
+   produced black flashes while scrolling and made the link lists below the
+   index mosaic appear broken/collapsed (intrinsic-size mismatch caused
+   scrollbar jumps). The tags page already uses collapsed <details>, which
+   skip rendering natively, so the optimization was both redundant and
+   harmful. Do NOT reintroduce content-visibility on broad selectors. */
 
 /* Collapsible tag lists on the tags index page */
 .v2-tag-section details {

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -99,7 +99,7 @@ extra:
 extra_css:
   - https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap
   - static/extra.css
-  - static/v2_elite.css?v=2.7.0
+  - static/v2_elite.css?v=2.9.2
 
 extra_javascript:
   - static/v2_filter.js


### PR DESCRIPTION
## Summary
Removes `content-visibility: auto` from broad `<ul>`/`<ol>` selectors and `.v2-tag-section` in `v2_elite.css`.

## Why
On the slate (dark) theme this deferred painting caused:
- Black flashes while scrolling
- Link lists below the index mosaic appearing collapsed/broken (intrinsic-size mismatch → scrollbar jumps)

The tags page already uses collapsed `<details>` (native render skipping), so the optimization was redundant and harmful. Added a note to prevent reintroduction.

## Changes
- `docs/static/v2_elite.css` — remove content-visibility rules, add warning note (symlinked into `v2-docs/`, so both V1 & V2 portals get it)
- `v2-mkdocs.yml` — bump CSS cache-bust to `?v=2.9.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)