### PR TITLE
docs: bump CLAUDE.md current version to v2.9.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ This repository uses **Gitflow**. All agents MUST follow this branching model:
 10. Create GitHub Release: `gh release create vX.Y.Z --title "..." --notes "..."`
 
 ### Versioning
-- Current: `v2.6.0`
+- Current: `v2.9.2`
 - Format: `v{major}.{minor}.{patch}`
 - Major: breaking changes or architectural shifts
 - Minor: new features (like the digest engine, new modules)


### PR DESCRIPTION
Updates the stale `Current: v2.6.0` line in CLAUDE.md to `v2.9.2` to match the latest release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)