### PR TITLE
fix: deterministic inventory dump — last_checked as INTEGER

### DIFF
--- a/src/inventory_manager.py
+++ b/src/inventory_manager.py
@@ -113,7 +113,7 @@ def save_inventory(inv: Dict, shard_file: str = None):
         addition_method TEXT,
         content_hash TEXT,
         health_score REAL,
-        last_checked REAL,
+        last_checked INTEGER,
         needs_ai_refresh BOOLEAN,
         discovered_at TEXT,
         last_ai_eval TEXT,
@@ -139,7 +139,16 @@ def save_inventory(inv: Dict, shard_file: str = None):
     for url, entry in inv.items():
         if not isinstance(entry, dict):
             continue
-            
+
+        # last_checked is a coarse staleness timestamp (epoch seconds). Normalize
+        # it to int on the entry itself — before building the SQL record AND the
+        # YAML dump below — so both serializations agree, and SQLite's
+        # version-specific REAL->text float formatting can't rewrite every row on
+        # dump. Sub-second precision is not used by any reader.
+        lc = entry.get("last_checked")
+        if isinstance(lc, float):
+            entry["last_checked"] = int(lc)
+
         record = {col: entry.get(col) for col in columns if col not in ["hierarchy", "tags", "v1_locations", "v2_locations", "youtube_mosaic", "extra_metadata"]}
         record["url"] = url
         
@@ -160,7 +169,7 @@ def save_inventory(inv: Dict, shard_file: str = None):
         # Conversions
         record["is_microservice"] = 1 if record.get("is_microservice") else 0
         record["needs_ai_refresh"] = 1 if record.get("needs_ai_refresh") else 0
-        
+
         placeholders = ", ".join(["?"] * len(columns))
         values = [record[col] for col in columns]
         cursor.execute(f"INSERT OR REPLACE INTO resources ({', '.join(columns)}) VALUES ({placeholders})", values)


### PR DESCRIPTION
Code-only version of #381 (which conflicted with constant pipeline data churn).

## Problem
`last_checked` stored epoch seconds as `REAL`. SQLite's `iterdump` prints REAL with **version-specific float precision**, so a locally regenerated `inventory.sql` diverged from CI's (`1.779…608e+09` vs `1.779…608879e+09`).

## Fix
Normalize `last_checked` to **int** on the entry before *both* the SQL record and YAML dump; column type → `INTEGER`. Readers only do coarse day-level staleness comparisons, so sub-second precision is unused.

## Verification
- ✅ `load→save` idempotent for **both** `inventory.sql` and `inventory.yaml`
- ✅ Local (SQLite 3.40.1) output **byte-identical** to CI-equivalent `python:3.11` (SQLite 3.46.1)

## Why code-only
The actual data rewrite (last_checked float→int, ~10.9k rows + 281 gh_pushed) is a 22k-line diff that perpetually conflicts with the pipeline's frequent inventory commits. Shipping just the code lets the deterministic data regenerate on the next pipeline `save_inventory` (CI-compatible). The gh_pushed `N/A`→null cleanup can run as a one-off CI job via `scripts/normalize_gh_pushed.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)