### PR TITLE
fix: align Intelligence Digest hero card height with the other 4

### DIFF
--- a/docs/static/v2_elite.css
+++ b/docs/static/v2_elite.css
@@ -363,9 +363,15 @@ a {
 }
 
 .hero-badge-icon {
-  font-size: 2rem;
+  /* Match the 100px logo <img> box on the other hero cards so the
+     emoji-based Intelligence Digest card is the same height. */
+  height: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 3.5rem;
   line-height: 1;
-  margin-bottom: 4px;
+  margin-bottom: 12px;
 }
 
 .hero-badge-title {

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -99,7 +99,7 @@ extra:
 extra_css:
   - https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap
   - static/extra.css
-  - static/v2_elite.css?v=2.9.2
+  - static/v2_elite.css?v=2.9.7
 
 extra_javascript:
   - static/v2_filter.js


### PR DESCRIPTION
The Intelligence Digest hero card rendered shorter than the other four. They use a 100px logo `<img>`; it uses an emoji `<div class=hero-badge-icon>` that was only ~32px tall. Fix gives `.hero-badge-icon` a 100px flex-centered box so all five cards match.

Kept the card (not redundant with Trending Now — it's the nav entry point to the `/tech-digest/` page of 3/6/12-month top picks, vs. the inline current-trending grid).

Cache-bust → `?v=2.9.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)