### PR TITLE
ci: make V2 Publisher push deterministic (04.1)

### DIFF
--- a/.github/workflows/04.1.agentic_v2_publish.yml
+++ b/.github/workflows/04.1.agentic_v2_publish.yml
@@ -124,37 +124,49 @@ jobs:
           python -m src.safety_readme
 
       - name: Commit and Push V2 Elite Updates
+        env:
+          PYTHONPATH: ${{ github.workspace }}
         run: |
           git config --global user.name "Nubenetes Bot"
           git config --global user.email "bot@nubenetes.com"
           git add -A
           if git diff --staged --quiet; then
             echo "No automated changes to commit."
-          else
-            git commit -m "feat: sync V2 elite curated edition and README metrics [skip ci]"
-            # Pull, rebase, and push with automatic resolution of README.md conflicts
-            for i in {1..5}; do
-              if git pull origin develop --rebase; then
-                if git push origin develop; then
-                  exit 0
-                fi
-              else
-                echo "Rebase conflict detected, attempting self-healing..."
-                # Discard local conflicting changes to README.md and accept remote
-                git checkout --ours README.md || git checkout --theirs README.md
-                git add README.md
-                # Continue rebase
-                GIT_EDITOR=true git rebase --continue || { git rebase --abort; git pull origin develop; }
-                # Re-run README sync to update metrics with remote state incorporated
-                python -m src.readme_updater
-                python -m src.safety_readme
-                git add README.md
-                git commit --amend --no-edit
-              fi
-              sleep 5
-            done
-            git push origin develop
+            exit 0
           fi
+          git commit -m "feat: sync V2 elite curated edition and README metrics [skip ci]"
+          OUR=$(git rev-parse HEAD)
+          # Deterministic publish loop (replaces the fragile rebase + --ours/--theirs
+          # self-healing that could hang on a conflict and discard the bot's metrics).
+          # The render is authoritative for its generated surface, so each attempt:
+          #   1. hard-resets to the freshest remote tip (no conflict possible),
+          #   2. overlays our generated outputs verbatim (docs/, v2-docs/, inventory,
+          #      news_digest) — source configs in data/ are left untouched,
+          #   3. regenerates README.md (a pure function of the inventory) on top,
+          #   4. commits and pushes; on rejection it retries from the new tip.
+          GENERATED="docs v2-docs data/inventory.yaml data/inventory.sql data/news_digest.json"
+          for i in {1..5}; do
+            echo "Publish attempt $i/5..."
+            git fetch origin develop
+            git reset --hard origin/develop
+            git checkout "$OUR" -- $GENERATED
+            python -m src.readme_updater
+            python -m src.safety_readme
+            git add -A
+            if git diff --staged --quiet; then
+              echo "Remote already matches this render. Nothing to push."
+              exit 0
+            fi
+            git commit -m "feat: sync V2 elite curated edition and README metrics [skip ci]"
+            if git push origin develop; then
+              echo "Push succeeded on attempt $i."
+              exit 0
+            fi
+            echo "Attempt $i rejected — remote advanced, retrying from fresh tip..."
+            sleep $((i * 3))
+          done
+          echo "::error::V2 publish push failed after 5 attempts (persistent write contention on develop)."
+          exit 1
 
       - name: Create or Update Promotion PR to Master
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[2.9.14]](https://github.com/nubenetes/awesome-kubernetes/releases/tag/v2.9.14) - 2026-06-19
+
+### Changed
+- **Deterministic V2 Publisher Push (04.1)**: Replaced the fragile rebase + `git checkout --ours/--theirs README.md` self-healing in `04.1.agentic_v2_publish.yml` — which could hang on a non-README conflict and silently discard the bot's README metrics — with the same deterministic model now used by `05.1`. The render is authoritative for its generated surface, so each attempt hard-resets to the freshest `origin/develop` tip, overlays the generated outputs verbatim (`docs/`, `v2-docs/`, `data/inventory.yaml`, `data/inventory.sql`, `data/news_digest.json` — source configs like `link_rules.yaml`/`special_assets.yaml` are deliberately left untouched), regenerates `README.md` on top, then commits and pushes with a 5-attempt retry. This never hangs on a conflict and never loses data. Also pinned `PYTHONPATH` on the step so the in-loop `readme_updater`/`safety_readme` calls always resolve `src`.
+
 ## [[2.9.13]](https://github.com/nubenetes/awesome-kubernetes/releases/tag/v2.9.13) - 2026-06-19
 
 ### Fixed


### PR DESCRIPTION
## Problem
`04.1.agentic_v2_publish.yml` used `git add -A` (full render) then a rebase loop with `git checkout --ours README.md || git checkout --theirs README.md` self-healing. That logic:
- could **hang** on any conflict outside README (e.g. `inventory.*`, `news_digest.json`);
- used inverted/confused `--ours/--theirs` rebase semantics that could **silently discard the bot's README metrics**;
- amended after a non-rebase fallback `git pull`, producing inconsistent commits.

Because it commits generated content, the `05.1` "reset --hard" trick can't be applied wholesale — `reset --hard` would drop the render. This PR adapts the same deterministic idea while preserving the render.

## Fix — render is authoritative for its generated surface
Each of 5 attempts:
1. `git fetch` + `git reset --hard origin/develop` (freshest tip, no conflict possible);
2. `git checkout $OUR -- docs v2-docs data/inventory.yaml data/inventory.sql data/news_digest.json` — overlay our generated outputs verbatim. **Source configs** (`link_rules.yaml`, `special_assets.yaml`, `curation_sources.yaml`, `structure_map.yaml`) are verified read-only and left untouched;
3. regenerate `README.md` (pure function of the inventory) on top;
4. commit + push; on rejection retry from the new tip.

Never hangs, never loses data. Also pins `PYTHONPATH` so in-loop `readme_updater`/`safety_readme` resolve `src`.

## Verification
- Generated surface confirmed by grepping pipeline write-targets; the 4 untouched `data/*.yaml` files have no write-mode refs in `src/`.
- Workflow YAML parses clean; step `env.PYTHONPATH` present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)