### PR TITLE
feat(v2): restructure home — Topic Map + Methodology pages, mosaic & a11y polish

### DIFF
--- a/docs/overrides/404.html
+++ b/docs/overrides/404.html
@@ -1,0 +1,23 @@
+{% extends "main.html" %}
+
+<!--
+  Branded 404. The portal cares about deep-link stability (see CLAUDE.md URL
+  policy), so a dead link lands on a helpful page with clear ways back rather
+  than the theme's bare "404 - Not found". Shared by V1 and V2 (custom_dir is
+  docs/overrides for both), so styling is self-contained and links are root-relative.
+-->
+{% block content %}
+<div style="text-align:center; max-width:42rem; margin:3rem auto; padding:0 1rem;">
+  <p style="font-size:6rem; font-weight:700; line-height:1; margin:0; opacity:0.15;">404</p>
+  <h1 style="margin-top:0.5rem;">This page took a wrong turn</h1>
+  <p style="font-size:0.9rem; opacity:0.8;">
+    The resource you are looking for may have moved or never existed. Use the
+    search at the top, or jump back to a known starting point below.
+  </p>
+  <div style="display:flex; gap:0.75rem; justify-content:center; flex-wrap:wrap; margin-top:1.5rem;">
+    <a href="/" class="md-button md-button--primary">🏠 Home</a>
+    <a href="/topic-map/" class="md-button">🗺️ Topic Map</a>
+    <a href="/v1/" class="md-button">📚 V1 Archive</a>
+  </div>
+</div>
+{% endblock %}

--- a/docs/static/v2_elite.css
+++ b/docs/static/v2_elite.css
@@ -1185,6 +1185,105 @@ input[type="text"] {
   color: #09090b;
 }
 
+/* ===================================================================
+   v2.9.16 — Home restructure: hero badge row, Topic Map grid,
+   mosaic labels, responsive video embeds
+   =================================================================== */
+
+/* Hero badge row (was an inline flexbox style on the index) */
+.hero-badge-row {
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+  margin: 16px 0;
+  flex-wrap: wrap;
+}
+
+/* Indigo accent for the new Topic Map badge card */
+.hero-badge-card--indigo {
+  border-color: rgba(99, 102, 241, 0.2);
+  background: rgba(99, 102, 241, 0.02);
+}
+.hero-badge-card--indigo:hover {
+  background: rgba(99, 102, 241, 0.06) !important;
+  box-shadow: 0 8px 24px rgba(99, 102, 241, 0.18);
+  border-color: #6366f1 !important;
+}
+
+/* Topic Map: full category directory as a multi-column grid.
+   CSS columns flow the per-dimension sections into 3 (then 2, then 1)
+   columns; break-inside keeps a dimension block intact across columns. */
+.topic-map-grid {
+  column-count: 3;
+  column-gap: 2.5rem;
+  margin-top: 1.5rem;
+}
+.topic-map-dim {
+  break-inside: avoid;
+  -webkit-column-break-inside: avoid;
+  page-break-inside: avoid;
+  display: inline-block; /* helps WebKit honor break-inside */
+  width: 100%;
+  margin: 0 0 1.4rem;
+}
+.topic-map-dim h3 {
+  margin-top: 0;
+}
+.topic-map-dim ul {
+  margin-top: 0.3rem;
+}
+.topic-count {
+  display: inline-block;
+  margin-left: 0.35rem;
+  padding: 0 0.45rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  line-height: 1.4;
+  border-radius: 10px;
+  color: var(--md-default-fg-color--light);
+  background: var(--md-default-fg-color--lightest);
+  vertical-align: middle;
+}
+@media screen and (max-width: 76.1875em) {
+  .topic-map-grid { column-count: 2; }
+}
+@media screen and (max-width: 44.9375em) {
+  .topic-map-grid { column-count: 1; }
+}
+
+/* Visible label for each YouTube mosaic category block (was hidden in title=) */
+.mosaic-cat-label {
+  margin: 0 0 0.5rem;
+  padding-left: 0.55rem;
+  border-left: 3px solid var(--cat-color, #64748b);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--md-default-fg-color--light);
+  text-align: left;
+}
+
+/* Responsive, privacy-friendly video embeds (about page) */
+.video-embed-grid {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin: 24px 0;
+}
+.video-embed {
+  flex: 1 1 420px;
+  max-width: 480px;
+  aspect-ratio: 16 / 9;
+}
+.video-embed iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: 8px;
+}
+
 
 
 

--- a/src/reorganize_mosaic.py
+++ b/src/reorganize_mosaic.py
@@ -60,13 +60,17 @@ def build_v2_mosaic_markdown_from_channels(channels):
         cat_chans.sort(key=lambda x: x['order_v2'])
         
         # Open category block container
-        lines.append(f'<div markdown="1" style="border: 1px solid {cat_info["color"]}; border-radius: 8px; padding: 10px; margin: 8px 0; background: rgba(255, 255, 255, 0.01);" title="{cat_info["name"]}">')
+        lines.append(f'<div markdown="1" class="mosaic-cat-block" style="border: 1px solid {cat_info["color"]}; border-radius: 8px; padding: 10px; margin: 8px 0; background: rgba(255, 255, 255, 0.01);" title="{cat_info["name"]}">')
         lines.append('') # Mandatory blank line after block tag
-        
-        # Channel links
+
+        # Visible category label (previously only exposed via the hidden title= tooltip)
+        lines.append(f'<p class="mosaic-cat-label" style="--cat-color: {cat_info["color"]}">{cat_info["name"]}</p>')
+        lines.append('')
+
+        # Channel links (loading="lazy" — ~150 logos, almost all below the fold)
         chan_links = []
         for chan in cat_chans:
-            chan_links.append(f"[![{chan['title']}]({chan['image']}){{: style=\"width:48px; height:48px; object-fit:contain; margin:6px;\" .channel-logo}}]({chan['url']})")
+            chan_links.append(f"[![{chan['title']}]({chan['image']}){{: style=\"width:48px; height:48px; object-fit:contain; margin:6px;\" loading=\"lazy\" .channel-logo}}]({chan['url']})")
         
         lines.append(" ".join(chan_links))
         lines.append('')

--- a/src/v2_optimizer.py
+++ b/src/v2_optimizer.py
@@ -169,7 +169,7 @@ class V2VisionEngine:
         
         # --- SURGICAL GARBAGE COLLECTION ---
         # Track every file we generate
-        generated_files = {"index.md", "audit-log.md", "videos.md", "tags.md", "tech-digest.md", "industry-digest.md"}
+        generated_files = {"index.md", "audit-log.md", "videos.md", "tags.md", "tech-digest.md", "industry-digest.md", "topic-map.md", "methodology.md"}
         for f_name in v2_data.keys():
             generated_files.add(f_name)
 
@@ -1113,7 +1113,7 @@ class V2VisionEngine:
             "    </div>\n"
             "  </a>\n"
             "</div>\n\n"
-            "<div style=\"display: flex; justify-content: center; gap: 24px; margin: 16px 0; flex-wrap: wrap;\">\n"
+            "<div class=\"hero-badge-row\">\n"
             "  <a href=\"./kubernetes/\" style=\"text-decoration: none; color: inherit; display: block;\">\n"
             "    <div class=\"hero-badge-card hero-badge-card--cyan\">\n"
             "      <img src=\"/images/kubernetes_logo.png\" alt=\"Kubernetes\"/>\n"
@@ -1142,6 +1142,13 @@ class V2VisionEngine:
             "      <div class=\"hero-badge-subtitle\">Architect Video Library</div>\n"
             "    </div>\n"
             "  </a>\n"
+            "  <a href=\"./topic-map/\" style=\"text-decoration: none; color: inherit; display: block;\">\n"
+            "    <div class=\"hero-badge-card hero-badge-card--indigo\">\n"
+            "      <div class=\"hero-badge-icon\">🗺️</div>\n"
+            "      <div class=\"hero-badge-title\">Topic Map</div>\n"
+            "      <div class=\"hero-badge-subtitle\">All Categories · Directory</div>\n"
+            "    </div>\n"
+            "  </a>\n"
             "  <a href=\"./introduction/\" style=\"text-decoration: none; color: inherit; display: block;\">\n"
             "    <div class=\"hero-badge-card hero-badge-card--teal\">\n"
             "      <img src=\"/images/hero-car.png\" alt=\"Nubenetes Car\"/>\n"
@@ -1154,26 +1161,59 @@ class V2VisionEngine:
             "    The V2 Edition is a curated, high-density version of the Nubenetes archive. Using **Agentic AI Orchestration**, "
             "the system selects only the most relevant, stable, and impactful resources for the modern Cloud Native ecosystem (2026 and beyond).\n\n"
             f"{coverage_info}\n\n"
-            f"<center markdown=\"1\">\n{mosaic_html}\n</center>\n\n"
+            # Altitude fix: surface the fresh, dynamic Trending/Digest BEFORE the
+            # signature YouTube mosaic (which now closes the page as a brand showcase).
             f"{pulse_md}\n\n"
-            "## Strategic Dimensions\n"
-            "- **[🎥 Agentic Video Hub (Architectural Summary)](./videos/index.md)**\n\n"
+            "## The Cloud Native Universe We Track\n\n"
+            f"<center markdown=\"1\">\n{mosaic_html}\n</center>\n\n"
+            "---\n\n"
+            "**Reference:** [🗺️ Full Topic Map](./topic-map/) · "
+            "[📐 Methodology &amp; Maturity Taxonomy](./methodology/) · "
+            "[🎥 Agentic Video Hub](./videos/index.md)\n"
         )
-        
-        # Group by dimension for index
+
+        # Group by dimension (shared by the Topic Map directory page below).
         dim_groups = {}
         for f_name, info in data.items():
             dim_groups.setdefault(info["dim"], []).append(f_name)
-            
-        # Mandate: Use the order defined in self.dimensions for architectural flow
+
+        with open(os.path.join(V2_DIR, "index.md"), "w") as f:
+            f.write(index_md)
+
+        # --- Topic Map: full category directory in a multi-column grid -----------
+        def _count_links(node):
+            total = len(node.get("__links__", []))
+            for k, v in node.items():
+                if k != "__links__" and isinstance(v, dict):
+                    total += _count_links(v)
+            return total
+
+        topic_md = (
+            "# Topic Map\n\n"
+            "!!! tip \"The complete Nubenetes V2 directory\"\n"
+            "    Every curated category across all strategic dimensions, with the number of "
+            "AI-selected resources in each. Looking for the landing page? Back to the "
+            "[**2026 Vision**](/).\n\n"
+            "<div class=\"topic-map-grid\" markdown=\"1\">\n\n"
+        )
         for dim in self.dimensions.keys():
             if dim in dim_groups:
-                index_md += f"### {dim}\n"
+                topic_md += "<section class=\"topic-map-dim\" markdown=\"1\">\n\n"
+                topic_md += f"### {dim}\n\n"
                 for f in sorted(dim_groups[dim]):
-                    index_md += f"- **[{data[f]['title']}](./{f})**\n"
-        
-        index_md += (
-            "\n---\n\n"
+                    count = _count_links(data[f]["content"])
+                    topic_md += f"- **[{data[f]['title']}](./{f})** <span class=\"topic-count\">{count}</span>\n"
+                topic_md += "\n</section>\n\n"
+        topic_md += "</div>\n"
+        with open(os.path.join(V2_DIR, "topic-map.md"), "w") as f:
+            f.write(topic_md)
+
+        # --- Methodology: maturity taxonomy + technical impact reference ---------
+        methodology_md = (
+            "# Methodology\n\n"
+            "!!! abstract \"How Nubenetes V2 classifies and ranks resources\"\n"
+            "    The reference legends below explain the maturity tags and the technical "
+            "impact (star) scores applied to every resource in the portal.\n\n"
             "## The Maturity Taxonomy\n\n"
             "To ensure industrial-grade precision, every resource in V2 is classified using our proprietary 5-tier maturity system:\n\n"
             "| Tag | Description | Engineering Context |\n"
@@ -1197,7 +1237,7 @@ class V2VisionEngine:
             "| 🌟 | **Reference Only** | Basic documentation or historical reference without major current impact. | Standard Link |\n"
         )
         
-        with open(os.path.join(V2_DIR, "index.md"), "w") as f: f.write(index_md)
+        with open(os.path.join(V2_DIR, "methodology.md"), "w") as f: f.write(methodology_md)
 
         async def render_node(node, depth, base_slug, used_headers, is_intro=False):
             md = ""
@@ -1264,9 +1304,9 @@ class V2VisionEngine:
                     "## The Nubenetes Engineering Manifest\n\n"
                     "!!! quote \"The Positive Sum Game\"\n"
                     "    ==*\"Open Source is most successful when is played as a positive sum game\" (Sarah Novotny)*==\n\n"
-                    "<div style=\"display: flex; justify-content: center; gap: 16px; flex-wrap: wrap; margin: 24px 0;\">\n"
-                    "  <iframe width=\"480\" height=\"270\" src=\"https://www.youtube.com/embed/GZl7N8sXyEo\" title=\"Cowboy Bebop - Tank!\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" allowfullscreen></iframe>\n"
-                    "  <iframe width=\"480\" height=\"270\" src=\"https://www.youtube.com/embed/t_hdOVsdRSE\" title=\"Jimmy Sax - Time\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" allowfullscreen></iframe>\n"
+                    "<div class=\"video-embed-grid\">\n"
+                    "  <div class=\"video-embed\"><iframe src=\"https://www.youtube-nocookie.com/embed/GZl7N8sXyEo\" title=\"Cowboy Bebop - Tank!\" loading=\"lazy\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" allowfullscreen></iframe></div>\n"
+                    "  <div class=\"video-embed\"><iframe src=\"https://www.youtube-nocookie.com/embed/t_hdOVsdRSE\" title=\"Jimmy Sax - Time\" loading=\"lazy\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" allowfullscreen></iframe></div>\n"
                     "</div>\n\n"
                     "### 1. The Genesis: Munich 2018\n"
                     "Nubenetes was forged in the internals of a massive Cloud Native transformation for a **major multinational car manufacturer** in Munich. Coordinating hundreds of microservices, thousands of developers, and millions of end-users taught us a fundamental truth: **Standardization, Automation, and GitOps are not \"best practices\"—they are survival requirements.**\n\n"
@@ -1482,6 +1522,8 @@ class V2VisionEngine:
                 "nav:",
                 "  - \"🔙 Back to V1 (Exhaustive)\": https://nubenetes.com/v1/",
                 "  - \"The 2026 Vision\": index.md",
+                "  - \"Topic Map\": topic-map.md",
+                "  - \"Methodology\": methodology.md",
                 "  - \"Technical Tags\": tags.md",
                 "  - \"Intelligence Digest\":",
                 "    - \"Tech & Cloud Digest\": tech-digest.md",

--- a/v2-docs/about.md
+++ b/v2-docs/about.md
@@ -11,9 +11,9 @@
 !!! quote "The Positive Sum Game"
     ==*"Open Source is most successful when is played as a positive sum game" (Sarah Novotny)*==
 
-<div style="display: flex; justify-content: center; gap: 16px; flex-wrap: wrap; margin: 24px 0;">
-  <iframe width="480" height="270" src="https://www.youtube.com/embed/GZl7N8sXyEo" title="Cowboy Bebop - Tank!" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-  <iframe width="480" height="270" src="https://www.youtube.com/embed/t_hdOVsdRSE" title="Jimmy Sax - Time" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<div class="video-embed-grid">
+  <div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/GZl7N8sXyEo" title="Cowboy Bebop - Tank!" loading="lazy" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+  <div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/t_hdOVsdRSE" title="Jimmy Sax - Time" loading="lazy" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
 </div>
 
 ### 1. The Genesis: Munich 2018

--- a/v2-docs/about.md
+++ b/v2-docs/about.md
@@ -34,7 +34,7 @@ We prioritize established frameworks and enterprise standards over ad-hoc, unmai
 #### 2.4. Avoiding Engineering Anti-Patterns
 We combat the culture of **Promotion-Based Development (PBD)**, where complexity is manufactured for personal career visibility rather than business value. 
 
-  - [Promotion-Based Development: A Fast Track to Mediocrity](https://vadimkravcenko.com/shorts/promotion-based-development/) <span class='md-tag md-tag--secondary'>[GUIDE]</span> — Dissects how rewarding "shiny new things" over battle-tested stability leads to fragile architectures.
+  - [Promotion-Based Development: A Fast Track to Mediocrity](https://vadimkravcenko.com/shorts/promotion-based-development) <span class='md-tag md-tag--secondary'>[GUIDE]</span> — Dissects how rewarding "shiny new things" over battle-tested stability leads to fragile architectures.
   - [Reddit: The Reality of Promotion-Driven Development](https://www.reddit.com/r/ExperiencedDevs/comments/pw6vuv/promotion_driven_development) <span class='md-tag md-tag--info'>[COMMUNITY-TOOL]</span> — A raw, evidence-based discussion from senior engineers on the industry's most common misaligned incentives.
 
 ### 3. The Architectural North Star
@@ -136,7 +136,7 @@ While certifications like CKA are prominent on CVs, they are frequently utilized
 #### Terraform Boilerplates
 
 ??? note "Terraform Kubernetes Boilerplates 🌟"
-    **[Access Resource](https://nubenetes.com/terraform/)** 🌟🌟🌟🌟🌟 | Level: Advanced
+    **[Access Resource](https://nubenetes.com/terraform)** 🌟🌟🌟🌟🌟 | Level: Advanced
     
     A library of enterprise-stable Terraform templates configured specifically for modern Kubernetes environments (EKS, GKE, AKS). Includes pre-tested infrastructure specifications for VPC topologies, private nodes, and dynamic ingress setups.
 

--- a/v2-docs/index.md
+++ b/v2-docs/index.md
@@ -24,7 +24,7 @@
   </a>
 </div>
 
-<div style="display: flex; justify-content: center; gap: 24px; margin: 16px 0; flex-wrap: wrap;">
+<div class="hero-badge-row">
   <a href="./kubernetes/" style="text-decoration: none; color: inherit; display: block;">
     <div class="hero-badge-card hero-badge-card--cyan">
       <img src="/images/kubernetes_logo.png" alt="Kubernetes"/>
@@ -53,6 +53,13 @@
       <div class="hero-badge-subtitle">Architect Video Library</div>
     </div>
   </a>
+  <a href="./topic-map/" style="text-decoration: none; color: inherit; display: block;">
+    <div class="hero-badge-card hero-badge-card--indigo">
+      <div class="hero-badge-icon">🗺️</div>
+      <div class="hero-badge-title">Topic Map</div>
+      <div class="hero-badge-subtitle">All Categories · Directory</div>
+    </div>
+  </a>
   <a href="./introduction/" style="text-decoration: none; color: inherit; display: block;">
     <div class="hero-badge-card hero-badge-card--teal">
       <img src="/images/hero-car.png" alt="Nubenetes Car"/>
@@ -78,50 +85,6 @@
     - **GitHub Metadata Coverage**: 1764 / 1764 (100.0%) - *Critical for Maturity Tagging*
     - **Status**: The system is incrementally processing pending resources to complete the knowledge graph.
 
-
-<center markdown="1">
-<div markdown="1" style="border: 1px solid #8b5cf6; border-radius: 8px; padding: 10px; margin: 8px 0; background: rgba(255, 255, 255, 0.01);" title="AI & Advanced Tech">
-
-[![Google Gemini](images/google_gemini_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@GoogleGemini) [![Google DeepMind](images/google_deepmind_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@googledeepmind) [![Anthropic](images/anthropic_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@anthropic-ai) [![OpenAI](images/openai_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/OpenAI) [![Meta AI](images/meta_ai_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@aiatmeta) [![Microsoft Copilot](images/microsoft_copilot_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@Microsoft.Copilot) [![Microsoft Reactor](images/microsoft_reactor_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@MicrosoftReactor) [![dotcsv](images/dotcsv.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@DotCSV) [![Gustavo Entrala](images/gustavo_entrala.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@gustavo-entrala)
-
-</div>
-
-<div markdown="1" style="border: 1px solid #3b82f6; border-radius: 8px; padding: 10px; margin: 8px 0; background: rgba(255, 255, 255, 0.01);" title="Cloud Providers & Core Infrastructure">
-
-[![aws videos](images/aws_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/amazonwebservices) [![azure videos](images/azure_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/MicrosoftAzure) [![gcp videos](images/gcp_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/user/googlecloudplatform) [![gcp videos new](images/gcp_logo_v2.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@googlecloudtech) [![ibm cloud videos](images/ibm_cloud_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/IBMTechnology) [![oraclecloud videos](images/oracle_cloud_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/OracleCloudInfrastructure) [![digitalocean videos](images/digital_ocean_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Digitalocean) [![cloudflare](images/cloudflare_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/cloudflare) [![scaleway cloud](images/scaleway_cloud.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Scaleway-Cloud) [![openstack](images/openstack_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/OpenStackFoundation) [![alibaba cloud](images/alibaba_cloud.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/AlibabaCloud) [![linode cloud](images/linode_cloud.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/linode) [![gaia-x](images/gaia_x.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/channel/UCB5WMc2FfrxKzfd7XIODoMw) [![kyndryl](images/kyndryl_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@kyndryl) [![Arsys](images/arsys_logo.svg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@arsys)
-
-</div>
-
-<div markdown="1" style="border: 1px solid #10b981; border-radius: 8px; padding: 10px; margin: 8px 0; background: rgba(255, 255, 255, 0.01);" title="Cloud Native Platforms & Kubernetes">
-
-[![cncf videos](images/cncf_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/cloudnativefdn) [![kubernetes logo](images/kubernetes_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/kubernetescommunity) [![redhat videos](images/redhat_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/redhat) [![openshift videos](images/openshift_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/OpenShift) [![rancher logo](images/rancher-logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Rancher) [![vmware tanzu logo](images/vmware_tanzu_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/VMwareTanzu) [![argocd project](images/argoproj.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/channel/UCOvYmppcbOPm1viN6ust3lA) [![fluxcd](images/fluxcd.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/channel/UCoZxt-YMhGHb20ZkvcCc5KA) [![keptn](images/keptn_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/keptn) [![netbox](images/netboxlabs_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@NetBoxLabs) [![kubefm](images/kubefm_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@kubefm) [![container days](images/containerdays.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/ContainerDays) [![tetrate](images/tetrate_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Tetrate)
-
-</div>
-
-<div markdown="1" style="border: 1px solid #f59e0b; border-radius: 8px; padding: 10px; margin: 8px 0; background: rgba(255, 255, 255, 0.01);" title="DevOps, CI/CD, IaC & GitOps">
-
-[![docker videos](images/docker_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/DockerIo) [![cloudbees videos](images/cloudbees_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/CloudBeesTV) [![jenkins videos](images/jenkins-logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/jenkinscicd) [![jenkins-x videos](images/jenkins_x_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/channel/UCN2kblPjXKMcjjVYmwvquvg) [![spinnaker videos](images/spinnaker_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/channel/UCcxQbw8kT1-FRhFhO2QCetg) [![harhicorp videos](images/hashicorp_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/HashiCorp) [![pulumi videos](images/pulumi_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/PulumiTV) [![Azure Terraformer](images/azure-terraformer.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@azure-terraformer) [![Ned in the Cloud](images/nedinthecloud.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@NedintheCloud) [![github videos](images/github_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/GitHub) [![gitlab video](images/gitlab_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Gitlab) [![gitkraken](images/gitkraken_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Gitkraken) [![atlassian videos](images/atlassian_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Atlassian) [![postman videos](images/postman_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/postman) [![swagger videos](images/smartbear_swagger_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Smartbear) [![jfrog](images/jfrog_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/JFrogInc) [![sonatype](images/sonatype_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Sonatypeinc) [![sonarsource sonarqube](images/sonarsource_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/channel/UCS5-gTYteN9rnFd98YxYtrA) [![ContinuousDeliveryFoundation](images/ContinuousDeliveryFoundation.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/ContinuousDeliveryFoundation) [![azure devops](images/azure_devops_youtube.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/AzureDevOps)
-
-</div>
-
-<div markdown="1" style="border: 1px solid #ec4899; border-radius: 8px; padding: 10px; margin: 8px 0; background: rgba(255, 255, 255, 0.01);" title="Observability, Databases & Cloud Storage">
-
-[![prometheus videos](images/prometheus_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/PrometheusIo) [![grafana videos](images/grafana_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Grafana) [![istio videos](images/istio_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Istio) [![elastic videos](images/elasticsearch_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Elastic) [![dynatrace videos](images/dynatrace_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/dynatrace) [![appdynamics videos](images/appdynamics_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/appdynamics) [![newrelic videos](images/newrelic_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/NewRelicInc) [![tigera calico](images/tigera_calico_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/channel/UC8uN3yhpeBeerGNwDiQbcgw) [![weavecloud](images/weavecloud_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/WeaveWorksInc) [![crunchydata](images/crunchydata_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/CrunchyDataPostgres) [![liquibase video](images/liquibase_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/channel/UC5qMsRjObu685rTBq0PJX8w) [![cockroachdb](images/cockroachdb_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/cockroachdb) [![mongodb](images/mongodb_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/MongoDBofficial) [![redis](images/redis_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Redisinc) [![confluent video](images/confluent_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Confluent) [![kubemq video](images/kubemq_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/channel/UCud7fErZAyMC6lHT_cWZNfA) [![openebs](images/openebs_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/channel/UC3ywadaAUQ1FI4YsHZ8wa0g) [![storageos](images/storageos_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/channel/UCm63IQg81KP9vXRWSHQpu1w) [![robin](images/robin_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/channel/UCt7N400Z8gB_3yKq1qrjP2w) [![portworx](images/portworx_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Portworx) [![ClickHouse](images/clickhouse_logo.svg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@ClickHouseDB)
-
-</div>
-
-<div markdown="1" style="border: 1px solid #14b8a6; border-radius: 8px; padding: 10px; margin: 8px 0; background: rgba(255, 255, 255, 0.01);" title="Development, Testing & Collaboration">
-
-[![vscode videos](images/vscode_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Code) [![Playwright](images/playwright_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@Playwrightdev) [![chrome developers videos](images/chromedevtools_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/GoogleChromeDevelopers) [![mozilla developer](images/mozilla_developer_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/MozillaDeveloper) [![rh devel](images/rh_developer_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/RedHatDevelopers) [![spring logo](images/spring-logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/user/SpringSourceDev) [![quarkus logo](images/quarkus-logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Quarkusio) [![lightbend videos](images/lightbend_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Lightbend-TV) [![lambdatest](images/lambdatest.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/LambdaTest) [![rocket_chat](images/rocket_chat_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/RocketChatApp) [![slack](images/slack_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Slackhq) [![mattermost](images/mattermost_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/MattermostHQ) [![microsoft365](images/microsoft_365_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/microsoft365) [![openproject](images/openproject_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/OpenProjectCommunity)
-
-</div>
-
-<div markdown="1" style="border: 1px solid #64748b; border-radius: 8px; padding: 10px; margin: 8px 0; background: rgba(255, 255, 255, 0.01);" title="Tech E-Learning, Influencers & Communities">
-
-[![cloud academy](images/cloud_academy_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Cloudacademy) [![acloudguru](images/acloudguru_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/AcloudGuru) [![devops_tv](images/devops_tv_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Devopsdotcom) [![xebialabs](images/xebialabs_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/XebiaLabs) [![devops library](images/devops_library_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Devopslibrary) [![codecademy](images/codecademy.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/codecademy) [![coursera](images/coursera_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/user/coursera) [![academind](images/academind_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Academind) [![guru99](images/guru99_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/guru99comm) [![intellipaat](images/intellipaat_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Intellipaat) [![cloud quick POCs](images/cloudquickpocs.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/channel/UCv9MUffHWyo2GgLIDLVu0KQ) [![thetips4you](images/thethips4you.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Thetips4you) [![cloud learnhub](images/cloud_learn_hub.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/channel/UC57acx8sCmE7uFHfVMvIlNg) [![John Savill](images/John_Savill.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/NTFAQGuy) [![microservice factory](images/microservice_factory.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/channel/UCorFV-WGnajyfNu4zPI0AAA) [![kubedb appscode](images/kubedb_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/AppsCodeInc) [![devops toolkit](images/devops_toolkit.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/DevOpsToolkit) [![ansible pilot](images/ansiblepilot.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/AnsiblePilot) [![codelytv](images/codelytv_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/CodelyTV) [![pelado nerd](images/pelado_nerd.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/PeladoNerd) [![hola mundo](images/hola_mundo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/HolaMundoDev) [![javier garzas](images/jgarzas.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/JavierGarz%C3%A1s) [![london IAC](images/londonIAC.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/LondonIAC) [![techworld nana](images/techworld_nana.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/TechWorldwithNana) [![honeypot](images/honeypot.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Honeypotio) [![Ali Spittel](images/aspittel.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/AliSpittelDev) [![thomas maurer](images/thomas_maurer.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/ThomasMaurerCloud) [![freecodecamp](images/freecodecamp.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/Freecodecamp) [![thenewstack](images/thenewstack.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/TheNewStack) [![the cloud girl](images/thecloudgirl.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/priyankavergadia) [![tina huang](images/tinahuang.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/TinaHuang1) [![azure cloud native](images/azure_cloud_native.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/channel/UC2Pk9GcHhlVV0R9CQIU6gLw) [![gps](images/gps.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/MadeByGPS) [![anais urlichs](images/anais_urlichs.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/AnaisUrlichs) [![the digital life](images/the_digital_life.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/TheDigitalLifeTech) [![Tech with Helen](images/techwithhelen.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@techwithhelen) [![bytebytego](images/bytebytego.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@ByteByteGo) [![midulive](images/midulive.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@midulive) [![returngis](images/returngis_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@returngis) [![Olena Kutsenko](images/olena_kutsenko.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@OlenaKutsenko) [![mouredev](images/mouredev.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@mouredev) [![CloudNativeMadrid](images/cloudnativemadrid_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@CloudNativeMadrid) [![itopstalk](images/itopstalk_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/@ITOpsTalk) [![dzone](images/dzone_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" .channel-logo}](https://www.youtube.com/c/dzone)
-
-</div>
-</center>
 
 <div class="trending-section">
 <div class="trending-section__title">🔥 Trending Now — Cloud Native Intelligence <span class="trending-section__updated">Updated Jun 19, 2026</span></div>
@@ -176,175 +139,66 @@
 </div>
 
 
-## Strategic Dimensions
-- **[🎥 Agentic Video Hub (Architectural Summary)](./videos/index.md)**
+## The Cloud Native Universe We Track
 
-### AI
-- **[AI Agents MCP](./ai-agents-mcp.md)**
-- **[AI](./ai.md)**
-- **[ChatGPT](./chatgpt.md)**
-- **[MLOps](./mlops.md)**
-### Architectural Foundations
-- **[About](./about.md)**
-- **[Cheatsheets](./cheatsheets.md)**
-- **[Cloud Arch Diagrams](./cloud-arch-diagrams.md)**
-- **[Customer](./customer.md)**
-- **[Demos](./demos.md)**
-- **[DevOps Tools](./devops-tools.md)**
-- **[Faq](./faq.md)**
-- **[Git](./git.md)**
-- **[Grafana](./grafana.md)**
-- **[Helm](./helm.md)**
-- **[Introduction](./introduction.md)**
-- **[Kubernetes Tools](./kubernetes-tools.md)**
-- **[Kubernetes Tutorials](./kubernetes-tutorials.md)**
-- **[Kubernetes](./kubernetes.md)**
-- **[Linux](./linux.md)**
-- **[Matrix Table](./matrix-table.md)**
-- **[Mkdocs](./mkdocs.md)**
-- **[Monitoring](./monitoring.md)**
-- **[Other Awesome Lists](./other-awesome-lists.md)**
-- **[Prometheus](./prometheus.md)**
-- **[Stackstorm](./stackstorm.md)**
-### Platform & Site Reliability
-- **[Chaos Engineering](./chaos-engineering.md)**
-- **[Developerportals](./developerportals.md)**
-- **[DevOps](./devops.md)**
-- **[Performance Testing With Jenkins And Jmeter](./performance-testing-with-jenkins-and-jmeter.md)**
-- **[Project Management Methodology](./project-management-methodology.md)**
-- **[Project Management Tools](./project-management-tools.md)**
-- **[QA](./qa.md)**
-- **[Scaffolding](./scaffolding.md)**
-- **[SRE](./sre.md)**
-- **[Test Automation Frameworks](./test-automation-frameworks.md)**
-- **[Testops](./testops.md)**
-### Hardened Infrastructure
-- **[Ansible](./ansible.md)**
-- **[Devsecops](./devsecops.md)**
-- **[Kubernetes Security](./kubernetes-security.md)**
-- **[Kustomize](./kustomize.md)**
-- **[Liquibase](./liquibase.md)**
-- **[Pulumi](./pulumi.md)**
-- **[Securityascode](./securityascode.md)**
-- **[Terraform](./terraform.md)**
-### Cloud Providers (Hyperscalers)
-- **[Googlecloudplatform](./GoogleCloudPlatform.md)**
-- **[AWS Architecture](./aws-architecture.md)**
-- **[AWS Containers](./aws-containers.md)**
-- **[AWS Data](./aws-data.md)**
-- **[AWS Databases](./aws-databases.md)**
-- **[AWS DevOps](./aws-devops.md)**
-- **[AWS Messaging](./aws-messaging.md)**
-- **[AWS Miscellaneous](./aws-miscellaneous.md)**
-- **[AWS Monitoring](./aws-monitoring.md)**
-- **[AWS Networking](./aws-networking.md)**
-- **[AWS Newfeatures](./aws-newfeatures.md)**
-- **[AWS Pricing](./aws-pricing.md)**
-- **[AWS Security](./aws-security.md)**
-- **[AWS Serverless](./aws-serverless.md)**
-- **[AWS Tools Scripts](./aws-tools-scripts.md)**
-- **[AWS Training](./aws-training.md)**
-- **[AWS](./aws.md)**
-- **[Azure](./azure.md)**
-- **[Digitalocean](./digitalocean.md)**
-- **[Edge Computing](./edge-computing.md)**
-- **[Ibm_Cloud](./ibm_cloud.md)**
-- **[Managed Kubernetes In Public Cloud](./managed-kubernetes-in-public-cloud.md)**
-- **[Oraclecloud](./oraclecloud.md)**
-- **[Public Cloud Solutions](./public-cloud-solutions.md)**
-### Networking & Service Mesh
-- **[Caching](./caching.md)**
-- **[Cloudflare](./cloudflare.md)**
-- **[Istio](./istio.md)**
-- **[Kubernetes Networking](./kubernetes-networking.md)**
-- **[Servicemesh](./servicemesh.md)**
-- **[Web Servers](./web-servers.md)**
-### The Container Stack
-- **[Container Managers](./container-managers.md)**
-- **[Docker](./docker.md)**
-- **[Kubectl Commands](./kubectl-commands.md)**
-- **[Kubernetes Alternatives](./kubernetes-alternatives.md)**
-- **[Kubernetes Autoscaling](./kubernetes-autoscaling.md)**
-- **[Kubernetes Backup Migrations](./kubernetes-backup-migrations.md)**
-- **[Kubernetes Based Devel](./kubernetes-based-devel.md)**
-- **[Kubernetes Client Libraries](./kubernetes-client-libraries.md)**
-- **[Kubernetes Monitoring](./kubernetes-monitoring.md)**
-- **[Kubernetes On Premise](./kubernetes-on-premise.md)**
-- **[Kubernetes Operators Controllers](./kubernetes-operators-controllers.md)**
-- **[Kubernetes Releases](./kubernetes-releases.md)**
-- **[Kubernetes Storage](./kubernetes-storage.md)**
-- **[Kubernetes Troubleshooting](./kubernetes-troubleshooting.md)**
-- **[Noops](./noops.md)**
-- **[OCP 3](./ocp3.md)**
-- **[OCP 4](./ocp4.md)**
-- **[Openshift](./openshift.md)**
-- **[Rancher](./rancher.md)**
-- **[Serverless](./serverless.md)**
-### Data & Advanced Analytics
-- **[Crunchydata](./crunchydata.md)**
-- **[Databases](./databases.md)**
-- **[Message Queue](./message-queue.md)**
-- **[NoSQL](./nosql.md)**
-- **[Yaml](./yaml.md)**
-### Engineering Pipeline
-- **[Argo](./argo.md)**
-- **[CI/CD Kubernetes Plugins](./cicd-kubernetes-plugins.md)**
-- **[CI/CD](./cicd.md)**
-- **[Flux](./flux.md)**
-- **[Gitops](./gitops.md)**
-- **[Jenkins Alternatives](./jenkins-alternatives.md)**
-- **[Jenkins](./jenkins.md)**
-- **[Keptn](./keptn.md)**
-- **[Openshift Pipelines](./openshift-pipelines.md)**
-- **[Registries](./registries.md)**
-- **[Sonarqube](./sonarqube.md)**
-- **[Tekton](./tekton.md)**
-### Developer Ecosystem
-- **[Angular](./angular.md)**
-- **[API](./api.md)**
-- **[Devel Sites](./devel-sites.md)**
-- **[Dotnet](./dotnet.md)**
-- **[Embedded Servlet Containers](./embedded-servlet-containers.md)**
-- **[Golang](./golang.md)**
-- **[Java And Java Performance Optimization](./java-and-java-performance-optimization.md)**
-- **[Java_App_Servers](./java_app_servers.md)**
-- **[Java_Frameworks](./java_frameworks.md)**
-- **[Javascript](./javascript.md)**
-- **[Linux Dev Env](./linux-dev-env.md)**
-- **[Maven Gradle](./maven-gradle.md)**
-- **[Postman](./postman.md)**
-- **[Python](./python.md)**
-- **[Visual Studio](./visual-studio.md)**
-### Career & Industry
-- **[Appointment Scheduling](./appointment-scheduling.md)**
-- **[Elearning](./elearning.md)**
-- **[Interview Questions](./interview-questions.md)**
+<center markdown="1">
+<div markdown="1" class="mosaic-cat-block" style="border: 1px solid #8b5cf6; border-radius: 8px; padding: 10px; margin: 8px 0; background: rgba(255, 255, 255, 0.01);" title="AI & Advanced Tech">
+
+<p class="mosaic-cat-label" style="--cat-color: #8b5cf6">AI & Advanced Tech</p>
+
+[![Google Gemini](images/google_gemini_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@GoogleGemini) [![Google DeepMind](images/google_deepmind_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@googledeepmind) [![Anthropic](images/anthropic_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@anthropic-ai) [![OpenAI](images/openai_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/OpenAI) [![Meta AI](images/meta_ai_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@aiatmeta) [![Microsoft Copilot](images/microsoft_copilot_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@Microsoft.Copilot) [![Microsoft Reactor](images/microsoft_reactor_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@MicrosoftReactor) [![dotcsv](images/dotcsv.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@DotCSV) [![Gustavo Entrala](images/gustavo_entrala.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@gustavo-entrala)
+
+</div>
+
+<div markdown="1" class="mosaic-cat-block" style="border: 1px solid #3b82f6; border-radius: 8px; padding: 10px; margin: 8px 0; background: rgba(255, 255, 255, 0.01);" title="Cloud Providers & Core Infrastructure">
+
+<p class="mosaic-cat-label" style="--cat-color: #3b82f6">Cloud Providers & Core Infrastructure</p>
+
+[![aws videos](images/aws_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/amazonwebservices) [![azure videos](images/azure_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/MicrosoftAzure) [![gcp videos](images/gcp_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/user/googlecloudplatform) [![gcp videos new](images/gcp_logo_v2.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@googlecloudtech) [![ibm cloud videos](images/ibm_cloud_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/IBMTechnology) [![oraclecloud videos](images/oracle_cloud_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/OracleCloudInfrastructure) [![digitalocean videos](images/digital_ocean_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Digitalocean) [![cloudflare](images/cloudflare_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/cloudflare) [![scaleway cloud](images/scaleway_cloud.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Scaleway-Cloud) [![openstack](images/openstack_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/OpenStackFoundation) [![alibaba cloud](images/alibaba_cloud.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/AlibabaCloud) [![linode cloud](images/linode_cloud.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/linode) [![gaia-x](images/gaia_x.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/channel/UCB5WMc2FfrxKzfd7XIODoMw) [![kyndryl](images/kyndryl_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@kyndryl) [![Arsys](images/arsys_logo.svg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@arsys)
+
+</div>
+
+<div markdown="1" class="mosaic-cat-block" style="border: 1px solid #10b981; border-radius: 8px; padding: 10px; margin: 8px 0; background: rgba(255, 255, 255, 0.01);" title="Cloud Native Platforms & Kubernetes">
+
+<p class="mosaic-cat-label" style="--cat-color: #10b981">Cloud Native Platforms & Kubernetes</p>
+
+[![cncf videos](images/cncf_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/cloudnativefdn) [![kubernetes logo](images/kubernetes_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/kubernetescommunity) [![redhat videos](images/redhat_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/redhat) [![openshift videos](images/openshift_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/OpenShift) [![rancher logo](images/rancher-logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Rancher) [![vmware tanzu logo](images/vmware_tanzu_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/VMwareTanzu) [![argocd project](images/argoproj.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/channel/UCOvYmppcbOPm1viN6ust3lA) [![fluxcd](images/fluxcd.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/channel/UCoZxt-YMhGHb20ZkvcCc5KA) [![keptn](images/keptn_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/keptn) [![netbox](images/netboxlabs_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@NetBoxLabs) [![kubefm](images/kubefm_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@kubefm) [![container days](images/containerdays.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/ContainerDays) [![tetrate](images/tetrate_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Tetrate)
+
+</div>
+
+<div markdown="1" class="mosaic-cat-block" style="border: 1px solid #f59e0b; border-radius: 8px; padding: 10px; margin: 8px 0; background: rgba(255, 255, 255, 0.01);" title="DevOps, CI/CD, IaC & GitOps">
+
+<p class="mosaic-cat-label" style="--cat-color: #f59e0b">DevOps, CI/CD, IaC & GitOps</p>
+
+[![docker videos](images/docker_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/DockerIo) [![cloudbees videos](images/cloudbees_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/CloudBeesTV) [![jenkins videos](images/jenkins-logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/jenkinscicd) [![jenkins-x videos](images/jenkins_x_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/channel/UCN2kblPjXKMcjjVYmwvquvg) [![spinnaker videos](images/spinnaker_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/channel/UCcxQbw8kT1-FRhFhO2QCetg) [![harhicorp videos](images/hashicorp_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/HashiCorp) [![pulumi videos](images/pulumi_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/PulumiTV) [![Azure Terraformer](images/azure-terraformer.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@azure-terraformer) [![Ned in the Cloud](images/nedinthecloud.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@NedintheCloud) [![github videos](images/github_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/GitHub) [![gitlab video](images/gitlab_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Gitlab) [![gitkraken](images/gitkraken_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Gitkraken) [![atlassian videos](images/atlassian_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Atlassian) [![postman videos](images/postman_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/postman) [![swagger videos](images/smartbear_swagger_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Smartbear) [![jfrog](images/jfrog_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/JFrogInc) [![sonatype](images/sonatype_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Sonatypeinc) [![sonarsource sonarqube](images/sonarsource_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/channel/UCS5-gTYteN9rnFd98YxYtrA) [![ContinuousDeliveryFoundation](images/ContinuousDeliveryFoundation.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/ContinuousDeliveryFoundation) [![azure devops](images/azure_devops_youtube.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/AzureDevOps)
+
+</div>
+
+<div markdown="1" class="mosaic-cat-block" style="border: 1px solid #ec4899; border-radius: 8px; padding: 10px; margin: 8px 0; background: rgba(255, 255, 255, 0.01);" title="Observability, Databases & Cloud Storage">
+
+<p class="mosaic-cat-label" style="--cat-color: #ec4899">Observability, Databases & Cloud Storage</p>
+
+[![prometheus videos](images/prometheus_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/PrometheusIo) [![grafana videos](images/grafana_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Grafana) [![istio videos](images/istio_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Istio) [![elastic videos](images/elasticsearch_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Elastic) [![dynatrace videos](images/dynatrace_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/dynatrace) [![appdynamics videos](images/appdynamics_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/appdynamics) [![newrelic videos](images/newrelic_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/NewRelicInc) [![tigera calico](images/tigera_calico_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/channel/UC8uN3yhpeBeerGNwDiQbcgw) [![weavecloud](images/weavecloud_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/WeaveWorksInc) [![crunchydata](images/crunchydata_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/CrunchyDataPostgres) [![liquibase video](images/liquibase_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/channel/UC5qMsRjObu685rTBq0PJX8w) [![cockroachdb](images/cockroachdb_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/cockroachdb) [![mongodb](images/mongodb_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/MongoDBofficial) [![redis](images/redis_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Redisinc) [![confluent video](images/confluent_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Confluent) [![kubemq video](images/kubemq_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/channel/UCud7fErZAyMC6lHT_cWZNfA) [![openebs](images/openebs_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/channel/UC3ywadaAUQ1FI4YsHZ8wa0g) [![storageos](images/storageos_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/channel/UCm63IQg81KP9vXRWSHQpu1w) [![robin](images/robin_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/channel/UCt7N400Z8gB_3yKq1qrjP2w) [![portworx](images/portworx_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Portworx) [![ClickHouse](images/clickhouse_logo.svg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@ClickHouseDB)
+
+</div>
+
+<div markdown="1" class="mosaic-cat-block" style="border: 1px solid #14b8a6; border-radius: 8px; padding: 10px; margin: 8px 0; background: rgba(255, 255, 255, 0.01);" title="Development, Testing & Collaboration">
+
+<p class="mosaic-cat-label" style="--cat-color: #14b8a6">Development, Testing & Collaboration</p>
+
+[![vscode videos](images/vscode_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Code) [![Playwright](images/playwright_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@Playwrightdev) [![chrome developers videos](images/chromedevtools_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/GoogleChromeDevelopers) [![mozilla developer](images/mozilla_developer_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/MozillaDeveloper) [![rh devel](images/rh_developer_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/RedHatDevelopers) [![spring logo](images/spring-logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/user/SpringSourceDev) [![quarkus logo](images/quarkus-logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Quarkusio) [![lightbend videos](images/lightbend_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Lightbend-TV) [![lambdatest](images/lambdatest.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/LambdaTest) [![rocket_chat](images/rocket_chat_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/RocketChatApp) [![slack](images/slack_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Slackhq) [![mattermost](images/mattermost_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/MattermostHQ) [![microsoft365](images/microsoft_365_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/microsoft365) [![openproject](images/openproject_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/OpenProjectCommunity)
+
+</div>
+
+<div markdown="1" class="mosaic-cat-block" style="border: 1px solid #64748b; border-radius: 8px; padding: 10px; margin: 8px 0; background: rgba(255, 255, 255, 0.01);" title="Tech E-Learning, Influencers & Communities">
+
+<p class="mosaic-cat-label" style="--cat-color: #64748b">Tech E-Learning, Influencers & Communities</p>
+
+[![cloud academy](images/cloud_academy_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Cloudacademy) [![acloudguru](images/acloudguru_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/AcloudGuru) [![devops_tv](images/devops_tv_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Devopsdotcom) [![xebialabs](images/xebialabs_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/XebiaLabs) [![devops library](images/devops_library_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Devopslibrary) [![codecademy](images/codecademy.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/codecademy) [![coursera](images/coursera_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/user/coursera) [![academind](images/academind_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Academind) [![guru99](images/guru99_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/guru99comm) [![intellipaat](images/intellipaat_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Intellipaat) [![cloud quick POCs](images/cloudquickpocs.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/channel/UCv9MUffHWyo2GgLIDLVu0KQ) [![thetips4you](images/thethips4you.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Thetips4you) [![cloud learnhub](images/cloud_learn_hub.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/channel/UC57acx8sCmE7uFHfVMvIlNg) [![John Savill](images/John_Savill.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/NTFAQGuy) [![microservice factory](images/microservice_factory.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/channel/UCorFV-WGnajyfNu4zPI0AAA) [![kubedb appscode](images/kubedb_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/AppsCodeInc) [![devops toolkit](images/devops_toolkit.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/DevOpsToolkit) [![ansible pilot](images/ansiblepilot.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/AnsiblePilot) [![codelytv](images/codelytv_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/CodelyTV) [![pelado nerd](images/pelado_nerd.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/PeladoNerd) [![hola mundo](images/hola_mundo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/HolaMundoDev) [![javier garzas](images/jgarzas.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/JavierGarz%C3%A1s) [![london IAC](images/londonIAC.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/LondonIAC) [![techworld nana](images/techworld_nana.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/TechWorldwithNana) [![honeypot](images/honeypot.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Honeypotio) [![Ali Spittel](images/aspittel.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/AliSpittelDev) [![thomas maurer](images/thomas_maurer.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/ThomasMaurerCloud) [![freecodecamp](images/freecodecamp.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/Freecodecamp) [![thenewstack](images/thenewstack.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/TheNewStack) [![the cloud girl](images/thecloudgirl.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/priyankavergadia) [![tina huang](images/tinahuang.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/TinaHuang1) [![azure cloud native](images/azure_cloud_native.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/channel/UC2Pk9GcHhlVV0R9CQIU6gLw) [![gps](images/gps.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/MadeByGPS) [![anais urlichs](images/anais_urlichs.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/AnaisUrlichs) [![the digital life](images/the_digital_life.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/TheDigitalLifeTech) [![Tech with Helen](images/techwithhelen.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@techwithhelen) [![bytebytego](images/bytebytego.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@ByteByteGo) [![midulive](images/midulive.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@midulive) [![returngis](images/returngis_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@returngis) [![Olena Kutsenko](images/olena_kutsenko.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@OlenaKutsenko) [![mouredev](images/mouredev.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@mouredev) [![CloudNativeMadrid](images/cloudnativemadrid_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@CloudNativeMadrid) [![itopstalk](images/itopstalk_logo.png){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/@ITOpsTalk) [![dzone](images/dzone_logo.jpg){: style="width:48px; height:48px; object-fit:contain; margin:6px;" loading="lazy" .channel-logo}](https://www.youtube.com/c/dzone)
+
+</div>
+</center>
 
 ---
 
-## The Maturity Taxonomy
-
-To ensure industrial-grade precision, every resource in V2 is classified using our proprietary 5-tier maturity system:
-
-| Tag | Description | Engineering Context |
-| :--- | :--- | :--- |
-| <a href="./tags/#de-facto-standard"><span class="md-tag md-tag--success">[DE FACTO STANDARD]</span></a> | The industry baseline. | Tools like Kubernetes, Terraform, or Prometheus that define the current architecture. |
-| <a href="./tags/#enterprise-stable"><span class="md-tag md-tag--success">[ENTERPRISE-STABLE]</span></a> | Battle-tested and reliable. | Proven solutions with strong community and commercial support. |
-| <a href="./tags/#emerging"><span class="md-tag md-tag--warning">[EMERGING]</span></a> | The cutting edge. | High-potential tools and patterns (e.g., AI Agents, MCP) shaping the future. |
-| <a href="./tags/#guide"><span class="md-tag md-tag--secondary">[GUIDE]</span></a> | Strategic knowledge. | High-quality tutorials, architectural deep-dives, and decision matrices. |
-| <a href="./tags/#case-study"><span class="md-tag md-tag--secondary">[CASE STUDY]</span></a> | Real-world evidence. | Practical implementations and architectural lessons from production environments. |
-| <a href="./tags/#community-tool"><span class="md-tag md-tag--info">[COMMUNITY-TOOL]</span></a> | Open-source ecosystem. | Valuable community-driven tools that enrich the ecosystem but may not have enterprise-grade support. |
-| <a href="./tags/#legacy"><span class="md-tag md-tag--critical">[LEGACY]</span></a> | Historical context. | Established tools that are being replaced or are primarily for maintaining older stacks. |
-| <a href="./tags/#spanish-content"><span class="md-tag md-tag--warning">[SPANISH CONTENT]</span></a> | Localized knowledge. | Resources in Spanish preserved for native speakers while indexed in English (Mandate 10). |
-
-## Technical Impact (Relevance Score)
-
-The stars accompanying each resource represent its **Technical Impact** and **Architectural Relevance** for a 2026 Senior Architect:
-
-| Impact | Level | Meaning | Visual Code |
-| :---: | :--- | :--- | :--- |
-| 🌟🌟🌟🌟🌟 | **Platinum Standard** | Critical industry foundation. Essential knowledge for any Cloud Native architecture. | `==[Highlighted Link]==` |
-| 🌟🌟🌟🌟 | **Gold Standard** | Highly recommended. Proven value and significant community/enterprise momentum. | `**[Bold Link]**` |
-| 🌟🌟🌟 | **Silver Standard** | Solid technical reference. Useful for specific use cases or established patterns. | Standard Link |
-| 🌟🌟 | **Bronze Standard** | Interesting alternative or niche tool. Good to have in the toolkit for specific scenarios. | Standard Link |
-| 🌟 | **Reference Only** | Basic documentation or historical reference without major current impact. | Standard Link |
+**Reference:** [🗺️ Full Topic Map](./topic-map/) · [📐 Methodology &amp; Maturity Taxonomy](./methodology/) · [🎥 Agentic Video Hub](./videos/index.md)

--- a/v2-docs/index.md
+++ b/v2-docs/index.md
@@ -1,4 +1,4 @@
-# Nubenetes Elite Portal (V2) | Awesome Kubernetes & Cloud [![Awesome](https://cdn.jsdelivr.net/gh/sindresorhus/awesome@d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+# Nubenetes Elite Portal (V2) | Awesome Kubernetes and Cloud [![Awesome](https://cdn.jsdelivr.net/gh/sindresorhus/awesome@d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
 !!! tip "Nubenetes V2 Elite Portal: AI-Curated & High-Density"
     You are browsing the AI-Curated V2 Elite Edition of Nubenetes. Looking for the complete historical archive? Explore the [**V1 Historical Archive**](/v1/).

--- a/v2-docs/methodology.md
+++ b/v2-docs/methodology.md
@@ -1,0 +1,31 @@
+# Methodology
+
+!!! abstract "How Nubenetes V2 classifies and ranks resources"
+    The reference legends below explain the maturity tags and the technical impact (star) scores applied to every resource in the portal.
+
+## The Maturity Taxonomy
+
+To ensure industrial-grade precision, every resource in V2 is classified using our proprietary 5-tier maturity system:
+
+| Tag | Description | Engineering Context |
+| :--- | :--- | :--- |
+| <a href="./tags/#de-facto-standard"><span class="md-tag md-tag--success">[DE FACTO STANDARD]</span></a> | The industry baseline. | Tools like Kubernetes, Terraform, or Prometheus that define the current architecture. |
+| <a href="./tags/#enterprise-stable"><span class="md-tag md-tag--success">[ENTERPRISE-STABLE]</span></a> | Battle-tested and reliable. | Proven solutions with strong community and commercial support. |
+| <a href="./tags/#emerging"><span class="md-tag md-tag--warning">[EMERGING]</span></a> | The cutting edge. | High-potential tools and patterns (e.g., AI Agents, MCP) shaping the future. |
+| <a href="./tags/#guide"><span class="md-tag md-tag--secondary">[GUIDE]</span></a> | Strategic knowledge. | High-quality tutorials, architectural deep-dives, and decision matrices. |
+| <a href="./tags/#case-study"><span class="md-tag md-tag--secondary">[CASE STUDY]</span></a> | Real-world evidence. | Practical implementations and architectural lessons from production environments. |
+| <a href="./tags/#community-tool"><span class="md-tag md-tag--info">[COMMUNITY-TOOL]</span></a> | Open-source ecosystem. | Valuable community-driven tools that enrich the ecosystem but may not have enterprise-grade support. |
+| <a href="./tags/#legacy"><span class="md-tag md-tag--critical">[LEGACY]</span></a> | Historical context. | Established tools that are being replaced or are primarily for maintaining older stacks. |
+| <a href="./tags/#spanish-content"><span class="md-tag md-tag--warning">[SPANISH CONTENT]</span></a> | Localized knowledge. | Resources in Spanish preserved for native speakers while indexed in English (Mandate 10). |
+
+## Technical Impact (Relevance Score)
+
+The stars accompanying each resource represent its **Technical Impact** and **Architectural Relevance** for a 2026 Senior Architect:
+
+| Impact | Level | Meaning | Visual Code |
+| :---: | :--- | :--- | :--- |
+| 🌟🌟🌟🌟🌟 | **Platinum Standard** | Critical industry foundation. Essential knowledge for any Cloud Native architecture. | `==[Highlighted Link]==` |
+| 🌟🌟🌟🌟 | **Gold Standard** | Highly recommended. Proven value and significant community/enterprise momentum. | `**[Bold Link]**` |
+| 🌟🌟🌟 | **Silver Standard** | Solid technical reference. Useful for specific use cases or established patterns. | Standard Link |
+| 🌟🌟 | **Bronze Standard** | Interesting alternative or niche tool. Good to have in the toolkit for specific scenarios. | Standard Link |
+| 🌟 | **Reference Only** | Basic documentation or historical reference without major current impact. | Standard Link |

--- a/v2-docs/topic-map.md
+++ b/v2-docs/topic-map.md
@@ -47,7 +47,7 @@
 
 <section class="topic-map-dim" markdown="1">
 
-### Platform & Site Reliability
+### Platform and Site Reliability
 
 - **[Chaos Engineering](./chaos-engineering.md)** <span class="topic-count">21</span>
 - **[Developerportals](./developerportals.md)** <span class="topic-count">40</span>
@@ -111,7 +111,7 @@
 
 <section class="topic-map-dim" markdown="1">
 
-### Networking & Service Mesh
+### Networking and Service Mesh
 
 - **[Caching](./caching.md)** <span class="topic-count">3</span>
 - **[Cloudflare](./cloudflare.md)** <span class="topic-count">3</span>
@@ -151,7 +151,7 @@
 
 <section class="topic-map-dim" markdown="1">
 
-### Data & Advanced Analytics
+### Data and Advanced Analytics
 
 - **[Crunchydata](./crunchydata.md)** <span class="topic-count">12</span>
 - **[Databases](./databases.md)** <span class="topic-count">46</span>
@@ -204,7 +204,7 @@
 
 <section class="topic-map-dim" markdown="1">
 
-### Career & Industry
+### Career and Industry
 
 - **[Appointment Scheduling](./appointment-scheduling.md)** <span class="topic-count">1</span>
 - **[Elearning](./elearning.md)** <span class="topic-count">4</span>

--- a/v2-docs/topic-map.md
+++ b/v2-docs/topic-map.md
@@ -1,0 +1,216 @@
+# Topic Map
+
+!!! tip "The complete Nubenetes V2 directory"
+    Every curated category across all strategic dimensions, with the number of AI-selected resources in each. Looking for the landing page? Back to the [**2026 Vision**](/).
+
+<div class="topic-map-grid" markdown="1">
+
+<section class="topic-map-dim" markdown="1">
+
+### AI
+
+- **[AI Agents MCP](./ai-agents-mcp.md)** <span class="topic-count">4</span>
+- **[AI](./ai.md)** <span class="topic-count">8</span>
+- **[ChatGPT](./chatgpt.md)** <span class="topic-count">4</span>
+- **[MLOps](./mlops.md)** <span class="topic-count">37</span>
+
+</section>
+
+<section class="topic-map-dim" markdown="1">
+
+### Architectural Foundations
+
+- **[About](./about.md)** <span class="topic-count">4</span>
+- **[Cheatsheets](./cheatsheets.md)** <span class="topic-count">14</span>
+- **[Cloud Arch Diagrams](./cloud-arch-diagrams.md)** <span class="topic-count">3</span>
+- **[Cloud Asset Inventory](./cloud-asset-inventory.md)** <span class="topic-count">1</span>
+- **[Customer](./customer.md)** <span class="topic-count">8</span>
+- **[Demos](./demos.md)** <span class="topic-count">104</span>
+- **[DevOps Tools](./devops-tools.md)** <span class="topic-count">6</span>
+- **[Faq](./faq.md)** <span class="topic-count">13</span>
+- **[Git](./git.md)** <span class="topic-count">19</span>
+- **[Grafana](./grafana.md)** <span class="topic-count">12</span>
+- **[Helm](./helm.md)** <span class="topic-count">20</span>
+- **[Introduction](./introduction.md)** <span class="topic-count">82</span>
+- **[Kubernetes Tools](./kubernetes-tools.md)** <span class="topic-count">139</span>
+- **[Kubernetes Tutorials](./kubernetes-tutorials.md)** <span class="topic-count">16</span>
+- **[Kubernetes](./kubernetes.md)** <span class="topic-count">153</span>
+- **[Linux](./linux.md)** <span class="topic-count">8</span>
+- **[Matrix Table](./matrix-table.md)** <span class="topic-count">1</span>
+- **[Mkdocs](./mkdocs.md)** <span class="topic-count">1</span>
+- **[Monitoring](./monitoring.md)** <span class="topic-count">74</span>
+- **[Other Awesome Lists](./other-awesome-lists.md)** <span class="topic-count">33</span>
+- **[Prometheus](./prometheus.md)** <span class="topic-count">16</span>
+- **[Stackstorm](./stackstorm.md)** <span class="topic-count">1</span>
+
+</section>
+
+<section class="topic-map-dim" markdown="1">
+
+### Platform & Site Reliability
+
+- **[Chaos Engineering](./chaos-engineering.md)** <span class="topic-count">21</span>
+- **[Developerportals](./developerportals.md)** <span class="topic-count">40</span>
+- **[DevOps](./devops.md)** <span class="topic-count">42</span>
+- **[Performance Testing With Jenkins And Jmeter](./performance-testing-with-jenkins-and-jmeter.md)** <span class="topic-count">6</span>
+- **[Project Management Methodology](./project-management-methodology.md)** <span class="topic-count">5</span>
+- **[Project Management Tools](./project-management-tools.md)** <span class="topic-count">1</span>
+- **[QA](./qa.md)** <span class="topic-count">9</span>
+- **[Scaffolding](./scaffolding.md)** <span class="topic-count">5</span>
+- **[SRE](./sre.md)** <span class="topic-count">22</span>
+- **[Test Automation Frameworks](./test-automation-frameworks.md)** <span class="topic-count">6</span>
+- **[Testops](./testops.md)** <span class="topic-count">4</span>
+
+</section>
+
+<section class="topic-map-dim" markdown="1">
+
+### Hardened Infrastructure
+
+- **[Ansible](./ansible.md)** <span class="topic-count">15</span>
+- **[Devsecops](./devsecops.md)** <span class="topic-count">135</span>
+- **[Kubernetes Security](./kubernetes-security.md)** <span class="topic-count">51</span>
+- **[Kustomize](./kustomize.md)** <span class="topic-count">2</span>
+- **[Liquibase](./liquibase.md)** <span class="topic-count">5</span>
+- **[Pulumi](./pulumi.md)** <span class="topic-count">1</span>
+- **[Securityascode](./securityascode.md)** <span class="topic-count">4</span>
+- **[Terraform](./terraform.md)** <span class="topic-count">41</span>
+
+</section>
+
+<section class="topic-map-dim" markdown="1">
+
+### Cloud Providers (Hyperscalers)
+
+- **[Googlecloudplatform](./GoogleCloudPlatform.md)** <span class="topic-count">33</span>
+- **[AWS Architecture](./aws-architecture.md)** <span class="topic-count">3</span>
+- **[AWS Containers](./aws-containers.md)** <span class="topic-count">9</span>
+- **[AWS Data](./aws-data.md)** <span class="topic-count">2</span>
+- **[AWS Databases](./aws-databases.md)** <span class="topic-count">7</span>
+- **[AWS DevOps](./aws-devops.md)** <span class="topic-count">5</span>
+- **[AWS Messaging](./aws-messaging.md)** <span class="topic-count">2</span>
+- **[AWS Miscellaneous](./aws-miscellaneous.md)** <span class="topic-count">15</span>
+- **[AWS Monitoring](./aws-monitoring.md)** <span class="topic-count">3</span>
+- **[AWS Networking](./aws-networking.md)** <span class="topic-count">12</span>
+- **[AWS Newfeatures](./aws-newfeatures.md)** <span class="topic-count">24</span>
+- **[AWS Pricing](./aws-pricing.md)** <span class="topic-count">1</span>
+- **[AWS Security](./aws-security.md)** <span class="topic-count">12</span>
+- **[AWS Serverless](./aws-serverless.md)** <span class="topic-count">35</span>
+- **[AWS Tools Scripts](./aws-tools-scripts.md)** <span class="topic-count">2</span>
+- **[AWS Training](./aws-training.md)** <span class="topic-count">1</span>
+- **[AWS](./aws.md)** <span class="topic-count">3</span>
+- **[Azure](./azure.md)** <span class="topic-count">66</span>
+- **[Digitalocean](./digitalocean.md)** <span class="topic-count">5</span>
+- **[Edge Computing](./edge-computing.md)** <span class="topic-count">2</span>
+- **[Ibm_Cloud](./ibm_cloud.md)** <span class="topic-count">5</span>
+- **[Managed Kubernetes In Public Cloud](./managed-kubernetes-in-public-cloud.md)** <span class="topic-count">60</span>
+- **[Oraclecloud](./oraclecloud.md)** <span class="topic-count">1</span>
+- **[Public Cloud Solutions](./public-cloud-solutions.md)** <span class="topic-count">8</span>
+
+</section>
+
+<section class="topic-map-dim" markdown="1">
+
+### Networking & Service Mesh
+
+- **[Caching](./caching.md)** <span class="topic-count">3</span>
+- **[Cloudflare](./cloudflare.md)** <span class="topic-count">3</span>
+- **[Istio](./istio.md)** <span class="topic-count">57</span>
+- **[Kubernetes Networking](./kubernetes-networking.md)** <span class="topic-count">63</span>
+- **[Servicemesh](./servicemesh.md)** <span class="topic-count">63</span>
+- **[Web Servers](./web-servers.md)** <span class="topic-count">5</span>
+
+</section>
+
+<section class="topic-map-dim" markdown="1">
+
+### The Container Stack
+
+- **[Container Managers](./container-managers.md)** <span class="topic-count">23</span>
+- **[Docker](./docker.md)** <span class="topic-count">28</span>
+- **[Kubectl Commands](./kubectl-commands.md)** <span class="topic-count">1</span>
+- **[Kubernetes Alternatives](./kubernetes-alternatives.md)** <span class="topic-count">25</span>
+- **[Kubernetes Autoscaling](./kubernetes-autoscaling.md)** <span class="topic-count">13</span>
+- **[Kubernetes Backup Migrations](./kubernetes-backup-migrations.md)** <span class="topic-count">9</span>
+- **[Kubernetes Based Devel](./kubernetes-based-devel.md)** <span class="topic-count">6</span>
+- **[Kubernetes Client Libraries](./kubernetes-client-libraries.md)** <span class="topic-count">9</span>
+- **[Kubernetes Monitoring](./kubernetes-monitoring.md)** <span class="topic-count">24</span>
+- **[Kubernetes On Premise](./kubernetes-on-premise.md)** <span class="topic-count">8</span>
+- **[Kubernetes Operators Controllers](./kubernetes-operators-controllers.md)** <span class="topic-count">8</span>
+- **[Kubernetes Releases](./kubernetes-releases.md)** <span class="topic-count">2</span>
+- **[Kubernetes Storage](./kubernetes-storage.md)** <span class="topic-count">14</span>
+- **[Kubernetes Troubleshooting](./kubernetes-troubleshooting.md)** <span class="topic-count">3</span>
+- **[Noops](./noops.md)** <span class="topic-count">1</span>
+- **[OCP 3](./ocp3.md)** <span class="topic-count">2</span>
+- **[OCP 4](./ocp4.md)** <span class="topic-count">29</span>
+- **[Openshift](./openshift.md)** <span class="topic-count">6</span>
+- **[Rancher](./rancher.md)** <span class="topic-count">9</span>
+- **[Serverless](./serverless.md)** <span class="topic-count">45</span>
+
+</section>
+
+<section class="topic-map-dim" markdown="1">
+
+### Data & Advanced Analytics
+
+- **[Crunchydata](./crunchydata.md)** <span class="topic-count">12</span>
+- **[Databases](./databases.md)** <span class="topic-count">46</span>
+- **[Message Queue](./message-queue.md)** <span class="topic-count">79</span>
+- **[NoSQL](./nosql.md)** <span class="topic-count">5</span>
+- **[Yaml](./yaml.md)** <span class="topic-count">14</span>
+
+</section>
+
+<section class="topic-map-dim" markdown="1">
+
+### Engineering Pipeline
+
+- **[Argo](./argo.md)** <span class="topic-count">13</span>
+- **[CI/CD Kubernetes Plugins](./cicd-kubernetes-plugins.md)** <span class="topic-count">1</span>
+- **[CI/CD](./cicd.md)** <span class="topic-count">31</span>
+- **[Flux](./flux.md)** <span class="topic-count">12</span>
+- **[Gitops](./gitops.md)** <span class="topic-count">24</span>
+- **[Jenkins Alternatives](./jenkins-alternatives.md)** <span class="topic-count">33</span>
+- **[Jenkins](./jenkins.md)** <span class="topic-count">26</span>
+- **[Keptn](./keptn.md)** <span class="topic-count">9</span>
+- **[Openshift Pipelines](./openshift-pipelines.md)** <span class="topic-count">16</span>
+- **[Registries](./registries.md)** <span class="topic-count">1</span>
+- **[Sonarqube](./sonarqube.md)** <span class="topic-count">4</span>
+- **[Tekton](./tekton.md)** <span class="topic-count">11</span>
+
+</section>
+
+<section class="topic-map-dim" markdown="1">
+
+### Developer Ecosystem
+
+- **[Angular](./angular.md)** <span class="topic-count">1</span>
+- **[API](./api.md)** <span class="topic-count">54</span>
+- **[Devel Sites](./devel-sites.md)** <span class="topic-count">3</span>
+- **[Dotnet](./dotnet.md)** <span class="topic-count">11</span>
+- **[Embedded Servlet Containers](./embedded-servlet-containers.md)** <span class="topic-count">1</span>
+- **[Golang](./golang.md)** <span class="topic-count">20</span>
+- **[Java And Java Performance Optimization](./java-and-java-performance-optimization.md)** <span class="topic-count">13</span>
+- **[Java_App_Servers](./java_app_servers.md)** <span class="topic-count">8</span>
+- **[Java_Frameworks](./java_frameworks.md)** <span class="topic-count">72</span>
+- **[Javascript](./javascript.md)** <span class="topic-count">3</span>
+- **[Linux Dev Env](./linux-dev-env.md)** <span class="topic-count">1</span>
+- **[Maven Gradle](./maven-gradle.md)** <span class="topic-count">12</span>
+- **[Postman](./postman.md)** <span class="topic-count">12</span>
+- **[Python](./python.md)** <span class="topic-count">47</span>
+- **[Visual Studio](./visual-studio.md)** <span class="topic-count">27</span>
+
+</section>
+
+<section class="topic-map-dim" markdown="1">
+
+### Career & Industry
+
+- **[Appointment Scheduling](./appointment-scheduling.md)** <span class="topic-count">1</span>
+- **[Elearning](./elearning.md)** <span class="topic-count">4</span>
+- **[Interview Questions](./interview-questions.md)** <span class="topic-count">12</span>
+- **[Recruitment](./recruitment.md)** <span class="topic-count">1</span>
+
+</section>
+
+</div>

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -34,7 +34,9 @@ theme:
     - navigation.top
     - navigation.tracking
     - navigation.sections
-    - navigation.expand
+    # navigation.expand intentionally disabled: with ~169 nav entries it forced
+    # every section open (heavy DOM, overwhelming). The Topic Map page now serves
+    # as the full directory; the left nav stays collapsed and scannable.
     - navigation.indexes
     - navigation.instant
     - navigation.instant.prefetch
@@ -102,7 +104,7 @@ extra:
 extra_css:
   - https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap
   - static/extra.css
-  - static/v2_elite.css?v=2.9.7
+  - static/v2_elite.css?v=2.9.16
 
 extra_javascript:
   - static/v2_filter.js?v=2.9.12
@@ -142,6 +144,8 @@ markdown_extensions:
 nav:
   - "🔙 Back to V1 (Exhaustive)": https://nubenetes.com/v1/
   - "The 2026 Vision": index.md
+  - "Topic Map": topic-map.md
+  - "Methodology": methodology.md
   - "Technical Tags": tags.md
   - "Agentic Video Hub":
       - videos/index.md


### PR DESCRIPTION
## Summary
Declutters the V2 landing page into a curated entry point. The full category directory and the reference legends move to dedicated pages, and the signature YouTube mosaic stays (reinforced, not removed).

## Home (`index.md`)
- ⬆️ **Trending/Digest now above the mosaic** — fresh, dynamic content first (fixes inverted altitude).
- 🗺️ **"Strategic Dimensions" (~130-link dump) replaced** by a Topic Map badge card + a slim reference footer.
- 🏷️ Mosaic framed with a **"The Cloud Native Universe We Track"** heading.

## New generated pages
- **`topic-map.md`** — full category directory by dimension in a **responsive multi-column CSS grid**, with **per-category resource counts**.
- **`methodology.md`** — Maturity Taxonomy + Technical Impact legend tables (moved out of the home).

## Mosaic (kept as brand signature, reinforced)
- 👁️ **Visible per-group category labels** (were hidden in `title=`).
- ⚡ **`loading="lazy"`** on the ~150 channel logos (LCP/perf win).

## `about.md` videos
- 🔒 `youtube-nocookie.com` + `loading="lazy"` + responsive `aspect-ratio` wrapper (aligns with the active `privacy` plugin).

## Config & cleanup
- Disabled `navigation.expand` (169-entry nav stayed fully open); Topic Map now serves as the full directory.
- Branded **404 page** with clear ways back (Home / Topic Map / V1 Archive).
- Hoisted repeated inline styles into CSS classes; bumped `v2_elite.css?v=2.9.16`.

## Validation
- `mkdocs build -f v2-mkdocs.yml` → exit 0; `topic-map/`, `methodology/`, `404.html` all generated.
- Pre-commit markdown schema check passed (0 errors).
- Locally-regenerated `inventory.sql`/`inventory.yaml` and unrelated category-page related-link churn were **excluded** from the PR; the generator changes are the source of truth (CI re-syncs artifacts).

## Follow-up (separate PR)
`git-revision-date-localized` plugin + JSON-LD structured data (deliberately scoped out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)