### PR TITLE
feat(v2/seo): per-page last-updated dates + JSON-LD structured data

### DIFF
--- a/.github/workflows/06.deploy_final.yml
+++ b/.github/workflows/06.deploy_final.yml
@@ -25,6 +25,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: true
+          # Full history so mkdocs-git-revision-date-localized can compute the
+          # real per-page "last updated" date (shallow clone => all build-date).
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -3,3 +3,51 @@
 {% block announce %}
   <strong>New:</strong> <a href="./tech-digest/">Intelligence Digest</a> — AI-curated trending resources across 26 categories
 {% endblock %}
+
+{#-
+  JSON-LD structured data (schema.org) for richer search results: declares the
+  WebSite (with a sitelinks SearchAction) and the publishing Organization.
+  Only the V2 portal uses this overrides dir (custom_dir: docs/overrides), so
+  this injects on the canonical nubenetes.com root; V1 uses the stock theme.
+-#}
+{% block extrahead %}
+  {{ super() }}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebSite",
+        "@id": "https://nubenetes.com/#website",
+        "url": "https://nubenetes.com/",
+        "name": "Nubenetes",
+        "description": "AI-curated portal for the modern Cloud Native ecosystem: high-density, ranked selection of top-tier Kubernetes, DevOps and Cloud resources.",
+        "publisher": { "@id": "https://nubenetes.com/#organization" },
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://nubenetes.com/?q={search_term_string}"
+          },
+          "query-input": "required name=search_term_string"
+        }
+      },
+      {
+        "@type": "Organization",
+        "@id": "https://nubenetes.com/#organization",
+        "name": "Nubenetes",
+        "url": "https://nubenetes.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://nubenetes.com/images/favicon-ultra.png"
+        },
+        "sameAs": [
+          "https://github.com/nubenetes/awesome-kubernetes",
+          "https://twitter.com/nubenetes",
+          "https://www.linkedin.com/groups/1937212/"
+        ]
+      }
+    ]
+  }
+  </script>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ youtube-transcript-api
 mkdocs-redirects>=1.2.3
 mkdocs-minify-plugin>=0.8.0
 mkdocs-rss-plugin>=1.15.0
+mkdocs-git-revision-date-localized-plugin>=1.3.0

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -58,6 +58,13 @@ theme:
 
 plugins:
   - search
+  # "Last updated" per-page date (freshness signal for SEO + reader trust).
+  # Needs full git history (fetch-depth: 0 in 06.deploy_final.yml); falls back
+  # to the build date when history is unavailable so the build never fails.
+  - git-revision-date-localized:
+      enable_creation_date: false
+      type: date
+      fallback_to_build_date: true
   - privacy
   - social:
       cards: true


### PR DESCRIPTION
Follow-up SEO PR (the **C + D** items deliberately scoped out of the v2-home-restructure work).

## C — Per-page "Last update" dates
- Added **`mkdocs-git-revision-date-localized-plugin`** to `requirements.txt` and enabled it in `v2-mkdocs.yml` (`type: date`, `fallback_to_build_date: true` so the build never fails when history is missing).
- Set **`fetch-depth: 0`** on the `06.deploy_final.yml` checkout so the plugin sees full git history (a shallow clone would make every page show the build date).
- Freshness signal for SEO + reader trust.

## D — JSON-LD structured data
- `WebSite` (with a sitelinks `SearchAction`) + publishing `Organization`, injected via an `extrahead` block in `docs/overrides/main.html` (shared V1/V2, both pointing at the canonical `nubenetes.com` root).
- Enables richer search results / knowledge-panel eligibility.

## Validation
- `mkdocs build -f v2-mkdocs.yml` → **exit 0**.
- JSON-LD extracted from rendered `index.html` → **parses**, `@types` = `[WebSite, Organization]`.
- `Last update` renders on content pages (verified on `kubernetes/`).

## Note
For frequently bulk-regenerated `v2-docs/` pages the "Last update" will cluster around the last publisher run — still an accurate freshness signal. Hand-authored/less-volatile pages get more varied dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)