### PR TITLE
fix(rss): deterministic feed lastBuildDate (kills residual develop↔master drift)

### DIFF
--- a/src/rss_generator.py
+++ b/src/rss_generator.py
@@ -61,7 +61,29 @@ def generate_rss() -> None:
     )
     items = items[:ITEMS_PER_FEED]
 
-    build_date = _rfc822(datetime.utcnow())
+    # Deterministic build date: derive from the digest's content timestamp
+    # (_meta.last_updated, the actual analysis date) instead of wall-clock now().
+    # Using now() rewrote <lastBuildDate> on every republish, so a regenerated-
+    # but-unchanged feed still differed between develop and master (perpetual
+    # cosmetic drift). Mirrors the v2_optimizer pattern that prefers
+    # _meta.last_updated over file mtime. Falls back to the most recent item
+    # date, then a fixed constant, so the feed is always a pure function of input.
+    build_dt = None
+    meta_updated = digest.get("_meta", {}).get("last_updated", "")
+    if meta_updated:
+        try:
+            build_dt = datetime.fromisoformat(meta_updated)
+        except Exception:
+            build_dt = None
+    if build_dt is None:
+        item_dates = []
+        for _it in items:
+            try:
+                item_dates.append(datetime.strptime(_it.get("date", ""), "%Y-%m-%d"))
+            except Exception:
+                pass
+        build_dt = max(item_dates) if item_dates else datetime(2026, 1, 1)
+    build_date = _rfc822(build_dt)
 
     lines = [
         '<?xml version="1.0" encoding="UTF-8"?>',

--- a/v2-docs/feed.xml
+++ b/v2-docs/feed.xml
@@ -5,7 +5,7 @@
     <link>https://nubenetes.com/</link>
     <description>AI-curated top picks from the Cloud Native &amp; Kubernetes ecosystem</description>
     <language>en</language>
-    <lastBuildDate>Sat, 20 Jun 2026 10:28:51 -0000</lastBuildDate>
+    <lastBuildDate>Sat, 20 Jun 2026 12:28:51 +0200</lastBuildDate>
     <atom:link href="https://nubenetes.com/feed.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>Kubecost 🌟</title>


### PR DESCRIPTION
## Residual drift after PR #401
After the PR Guardian drift fix, the only remaining `develop ↔ master` diff in `v2-docs/` was a 1-line **`<lastBuildDate>`** in `feed.xml`: `src/rss_generator.py` set it to `datetime.utcnow()`, so every republish rewrote it even when the digest was unchanged.

## Fix
Derive `lastBuildDate` from the digest's **`_meta.last_updated`** (the actual analysis date) — falling back to the most recent item date, then a fixed constant. The feed is now a **pure function of its input**: regenerating unchanged content yields byte-identical output. Mirrors the existing `v2_optimizer` pattern that prefers `_meta.last_updated` over file mtime.

## Validation
- Ran `python -m src.rss_generator` twice (2s apart) → **byte-identical `feed.xml`** (sha256 match).
- The feed now only changes when the digest content actually changes (weekly), reconciling cleanly at each release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)