### PR TITLE
fix(v2): don't inject resource/tag filter on Topic Map & Methodology

### DIFF
--- a/docs/static/v2_filter.js
+++ b/docs/static/v2_filter.js
@@ -27,7 +27,13 @@
             h1.textContent.includes("Nubenetes Elite Portal (V2)") ||
             h1.textContent.includes("Agentic Video Hub") ||
             h1.textContent.includes("Technical Tags Index") ||
-            h1.textContent.includes("Intelligence Digest")
+            h1.textContent.includes("Intelligence Digest") ||
+            // Topic Map / Methodology list categories and legend rows, not
+            // tagged resources: their <li> items carry no .md-tag, so the
+            // maturity pills would always filter to zero and the "X of Y
+            // resources" count is misleading. Skip them.
+            h1.textContent.includes("Topic Map") ||
+            h1.textContent.includes("Methodology")
         )) {
             return;
         }

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -114,7 +114,7 @@ extra_css:
   - static/v2_elite.css?v=2.9.17
 
 extra_javascript:
-  - static/v2_filter.js?v=2.9.12
+  - static/v2_filter.js?v=2.9.19
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Reported
On the **Topic Map** page the in-page tag/search filter appears, but there are no taggable resources there — so what is it for?

## Root cause
`v2_filter.js` auto-injects the filter widget wherever the page contains `<ul><li>` items. Topic Map lists **category links** (with resource counts) and Methodology lists **legend rows** — neither `<li>` carries a `.md-tag` maturity tag. Result:
- The maturity pills (De Facto Standard, Emerging, …) always filter to **zero**.
- The *"Showing X of Y resources"* counter mis-counts categories/rows as resources.

## Fix
Added **Topic Map** and **Methodology** to the widget's existing `<h1>`-based skip-list (same mechanism already used for the home, Video Hub, Tags index and Digest pages). Bumped `v2_filter.js?v=2.9.19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)