### PR TITLE
fix(rss): derive feed lastBuildDate from item content dates (fully kills feed drift)

### DIFF
--- a/src/rss_generator.py
+++ b/src/rss_generator.py
@@ -61,28 +61,27 @@ def generate_rss() -> None:
     )
     items = items[:ITEMS_PER_FEED]
 
-    # Deterministic build date: derive from the digest's content timestamp
-    # (_meta.last_updated, the actual analysis date) instead of wall-clock now().
-    # Using now() rewrote <lastBuildDate> on every republish, so a regenerated-
-    # but-unchanged feed still differed between develop and master (perpetual
-    # cosmetic drift). Mirrors the v2_optimizer pattern that prefers
-    # _meta.last_updated over file mtime. Falls back to the most recent item
-    # date, then a fixed constant, so the feed is always a pure function of input.
-    build_dt = None
-    meta_updated = digest.get("_meta", {}).get("last_updated", "")
-    if meta_updated:
+    # Deterministic build date = the freshest item's content date, so the feed
+    # is a pure function of its items. (This used wall-clock now() — rewritten on
+    # every republish — then _meta.last_updated, but that analysis timestamp is
+    # itself bumped on each publish even when the ranked content is unchanged, so
+    # the feed still drifted between develop and master. The item dates only move
+    # when the content actually changes.) Falls back to _meta.last_updated, then
+    # a fixed constant, only when no item carries a parseable date.
+    item_dates = []
+    for _it in items:
         try:
-            build_dt = datetime.fromisoformat(meta_updated)
+            item_dates.append(datetime.strptime(_it.get("date", ""), "%Y-%m-%d"))
         except Exception:
-            build_dt = None
-    if build_dt is None:
-        item_dates = []
-        for _it in items:
-            try:
-                item_dates.append(datetime.strptime(_it.get("date", ""), "%Y-%m-%d"))
-            except Exception:
-                pass
-        build_dt = max(item_dates) if item_dates else datetime(2026, 1, 1)
+            pass
+    if item_dates:
+        build_dt = max(item_dates)
+    else:
+        meta_updated = digest.get("_meta", {}).get("last_updated", "")
+        try:
+            build_dt = datetime.fromisoformat(meta_updated) if meta_updated else datetime(2026, 1, 1)
+        except Exception:
+            build_dt = datetime(2026, 1, 1)
     build_date = _rfc822(build_dt)
 
     lines = [

--- a/v2-docs/feed.xml
+++ b/v2-docs/feed.xml
@@ -5,7 +5,7 @@
     <link>https://nubenetes.com/</link>
     <description>AI-curated top picks from the Cloud Native &amp; Kubernetes ecosystem</description>
     <language>en</language>
-    <lastBuildDate>Sat, 20 Jun 2026 12:42:56 +0200</lastBuildDate>
+    <lastBuildDate>Thu, 18 Jun 2026 00:00:00 -0000</lastBuildDate>
     <atom:link href="https://nubenetes.com/feed.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>Kubecost 🌟</title>


### PR DESCRIPTION
## Why a follow-up to v2.9.19
Deriving `lastBuildDate` from `_meta.last_updated` only moved the drift one level down: that analysis timestamp is **bumped on every publish** even when the ranked content is unchanged, so `v2-docs/feed.xml` still differed between `develop` (12:42:56) and `master` (12:28:51).

## Definitive fix
Derive `lastBuildDate` from the **freshest item's content date** — the items only change when the ranking actually changes. `_meta.last_updated` / a constant remain as fallbacks only when no item has a parseable date.

## Validation
- Deterministic across reruns (sha256 match).
- `lastBuildDate` is now `Thu, 18 Jun 2026` (real content date).
- **Cross-branch proof**: the `develop` and `master` digests both yield max item date `2026-06-18`, so the regenerated `feed.xml` is now **byte-identical across branches** — the residual drift is fully eliminated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)