### PR TITLE
feat(v2/seo): unique per-page meta descriptions + robots.txt

### DIFF
--- a/src/v2_optimizer.py
+++ b/src/v2_optimizer.py
@@ -1189,6 +1189,10 @@ class V2VisionEngine:
             return total
 
         topic_md = (
+            "---\n"
+            "description: \"The complete Nubenetes V2 directory: every curated Kubernetes, "
+            "Cloud Native and DevOps category by strategic dimension, with resource counts.\"\n"
+            "---\n"
             "# Topic Map\n\n"
             "!!! tip \"The complete Nubenetes V2 directory\"\n"
             "    Every curated category across all strategic dimensions, with the number of "
@@ -1213,6 +1217,10 @@ class V2VisionEngine:
 
         # --- Methodology: maturity taxonomy + technical impact reference ---------
         methodology_md = (
+            "---\n"
+            "description: \"How Nubenetes V2 classifies and ranks resources: the maturity "
+            "taxonomy and technical impact (star) scoring used across the Elite portal.\"\n"
+            "---\n"
             "# Methodology\n\n"
             "!!! abstract \"How Nubenetes V2 classifies and ranks resources\"\n"
             "    The reference legends below explain the maturity tags and the technical "
@@ -1285,7 +1293,19 @@ class V2VisionEngine:
             used_headers = {info['long_title']} # Mandate 30: MD024 - Pre-populate with H1 to avoid duplicates
             # Formulate V1 counterpart link dynamically
             v1_link = f"/v1/{f_name.replace('.md', '/')}"
+            # Unique per-page SEO meta description (front-matter) so each page no
+            # longer falls back to the identical global site_description. Material
+            # emits it as <meta name="description"> + og:description.
+            _seo_title = str(info.get('title') or info['long_title'])[:60].strip()
+            _seo_desc = (
+                f"Curated, AI-ranked {_seo_title} resources for the 2026 Cloud Native "
+                f"architect: top-tier tools, guides and references ({info['dim']})."
+            )
+            _seo_desc = _seo_desc.replace("\\", " ").replace('"', "'").replace("\n", " ").strip()
             md = (
+                f"---\n"
+                f"description: \"{_seo_desc}\"\n"
+                f"---\n"
                 f"# {info['long_title']}\n\n"
                 f"!!! tip \"Nubenetes V2 Elite Portal\"\n"
                 f"    You are browsing the AI-Curated V2 Elite Edition. Looking for the exhaustive list of references? Check out the [**V1 Historical Archive**]({v1_link}).\n\n"

--- a/v2-docs/robots.txt
+++ b/v2-docs/robots.txt
@@ -1,0 +1,8 @@
+# Nubenetes — https://nubenetes.com
+# The Intelligent Cloud Native Archive (V1 exhaustive + V2 elite portal)
+
+User-agent: *
+Allow: /
+
+Sitemap: https://nubenetes.com/sitemap.xml
+Sitemap: https://nubenetes.com/v1/sitemap.xml


### PR DESCRIPTION
Audit of the V2 portal surfaced two SEO gaps (canonical, sitemap, JSON-LD and social cards were already fine).

## 1. Unique per-page meta descriptions
Every V2 page fell back to the **identical** global `site_description` — ~140 pages sharing one meta description (a duplicate-content SEO penalty). The generator now emits a unique `description:` front-matter per page (title + strategic dimension), which Material renders as `<meta name="description">` and `og:description`. Topic Map and Methodology get tailored descriptions.

## 2. robots.txt
Added `v2-docs/robots.txt` (lands at the site root via the deploy) allowing full crawl and referencing both sitemaps (root + `/v1/`).

## Not done (by design): noindex on the 12 redirect stubs
The merged stub pages (`chef`→`ansible`, `react`→`javascript`, …) already **0s meta-refresh redirect with `canonical` pointing at the target** — better SEO than noindex (passes authority), and the redirects plugin overwrites any front-matter anyway. Left untouched.

## Validation
- Built locally: `kubernetes`, `aws`, `topic-map` each carry a **distinct** meta description; `robots.txt` present in the build output.
- Pre-commit schema check passed. The ~140 generated pages pick up their front-matter on the next V2 Publisher run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)