### PR TITLE
feat(v2/seo): per-page CollectionPage JSON-LD with dates

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -50,4 +50,33 @@
     ]
   }
   </script>
+  {#-
+    Per-page structured data: a CollectionPage (each V2 page is a curated
+    collection of resources) tied to the WebSite/Organization above, with
+    datePublished / dateModified fed by the git-revision-date plugin. Enables
+    richer search results. Skipped on the homepage (already the WebSite entity).
+  -#}
+  {% if page and not page.is_homepage and page.canonical_url %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": {{ (page.canonical_url ~ "#webpage") | tojson }},
+    "url": {{ page.canonical_url | tojson }},
+    "name": {{ (page.title or config.site_name) | tojson }},
+    "isPartOf": { "@id": "https://nubenetes.com/#website" },
+    "publisher": { "@id": "https://nubenetes.com/#organization" },
+    "inLanguage": "en"
+    {%- if page.meta and page.meta.description %},
+    "description": {{ page.meta.description | tojson }}
+    {%- endif %}
+    {%- if page.meta and page.meta.git_creation_date_localized_raw_iso_date %},
+    "datePublished": {{ page.meta.git_creation_date_localized_raw_iso_date | tojson }}
+    {%- endif %}
+    {%- if page.meta and page.meta.git_revision_date_localized_raw_iso_date %},
+    "dateModified": {{ page.meta.git_revision_date_localized_raw_iso_date | tojson }}
+    {%- endif %}
+  }
+  </script>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Final SEO iteration: per-page structured data for rich results.

## What
Adds a second JSON-LD block per page — a schema.org **`CollectionPage`** (each V2 page is a curated collection of resources) tied to the existing `WebSite`/`Organization` `@graph` — carrying:
- `name`, `url`, `description`
- **`datePublished`** / **`dateModified`** fed by the `git-revision-date-localized` plugin's raw ISO dates (the creation/last-update dates added in v2.9.23).

## Why
Enables article/collection rich snippets in search results, now with real freshness dates — the high-value use of the per-page dates.

## Notes
- **Template-only** change (`docs/overrides/main.html`) — applied at build time, so no page regeneration / publisher run needed.
- The **homepage is skipped** (already the `WebSite` entity); only content pages get a `CollectionPage`.
- JSON is built with `| tojson` (safe escaping) and ordered so optional fields never leave a trailing comma.

## Validation
Built locally and parsed both JSON-LD blocks on `kubernetes`, `istio`, `topic-map`: each emits a **valid** `CollectionPage` with both dates (e.g. Kubernetes `datePublished=2026-05-18`, `dateModified=2026-06-20`); the home carries only the WebSite+Organization graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)