### PR TITLE
feat(v2/nav): disable navigation.tabs — full section list in left sidebar

### DIFF
--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -29,8 +29,9 @@ theme:
         icon: material/shield-moon-outline
         name: Switch to dark mode
   features:
-    - navigation.tabs
-    - navigation.tabs.sticky
+    # navigation.tabs / .sticky disabled: 18 top-level sections overflowed
+    # the tab bar (horizontal scroll). The left sidebar handles them as a
+    # standard vertical list and stays populated on every page incl. home.
     - navigation.top
     - navigation.tracking
     - navigation.sections


### PR DESCRIPTION
## Problem (confirmed in-browser)
The 18 top-level sections were rendered as a horizontal **tab bar** (`navigation.tabs`). On a laptop the labels total ~3300px vs a ~1400px viewport, so the tab bar **overflowed and required horizontal scroll** to reach the right-side dimensions (Cloud Providers, The Container Stack, … Career & Industry). It also left the **left sidebar nearly empty** on top-level pages like the home (only "The 2026 Vision" showed).

## Fix
Disable `navigation.tabs` (+ `.sticky`). The 18 sections move into the **standard vertical left sidebar**, which handles them via normal vertical scroll, stays populated on **every** page (incl. the home), and never clips.

## Verification
Built locally and compared:
| | tabs | nav links in sidebar |
|---|---|---|
| Before (tabs) | 18 | 23 (mostly the tab bar) |
| After (no tabs) | 0 | **178** (full tree) |

`navigation.prune` kept (no size difference: 88516 vs 88496 bytes). Theme-only change — the optimizer's nav-sync only rewrites the `nav:` block, so this is preserved across publishes.

## Trade-off
Loses the top "portal tabs" aesthetic for a conventional docs left-nav. Easily reversible (re-add the two feature lines). Preview: `mkdocs serve -f v2-mkdocs.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)