### PR TITLE
feat(v2): collapsible nested left nav + home section headings

### DIFF
--- a/src/v2_optimizer.py
+++ b/src/v2_optimizer.py
@@ -1113,6 +1113,7 @@ class V2VisionEngine:
             "    </div>\n"
             "  </a>\n"
             "</div>\n\n"
+            "## Explore the Ecosystem\n\n"
             "<div class=\"hero-badge-row\">\n"
             "  <a href=\"./kubernetes/\" style=\"text-decoration: none; color: inherit; display: block;\">\n"
             "    <div class=\"hero-badge-card hero-badge-card--cyan\">\n"
@@ -1163,6 +1164,7 @@ class V2VisionEngine:
             f"{coverage_info}\n\n"
             # Altitude fix: surface the fresh, dynamic Trending/Digest BEFORE the
             # signature YouTube mosaic (which now closes the page as a brand showcase).
+            "## Trending Now\n\n"
             f"{pulse_md}\n\n"
             "## The Cloud Native Universe We Track\n\n"
             f"<center markdown=\"1\">\n{mosaic_html}\n</center>\n\n"

--- a/v2-docs/index.md
+++ b/v2-docs/index.md
@@ -24,6 +24,8 @@
   </a>
 </div>
 
+## Explore the Ecosystem
+
 <div class="hero-badge-row">
   <a href="./kubernetes/" style="text-decoration: none; color: inherit; display: block;">
     <div class="hero-badge-card hero-badge-card--cyan">
@@ -85,6 +87,8 @@
     - **GitHub Metadata Coverage**: 1764 / 1764 (100.0%) - *Critical for Maturity Tagging*
     - **Status**: The system is incrementally processing pending resources to complete the knowledge graph.
 
+
+## Trending Now
 
 <div class="trending-section">
 <div class="trending-section__title">🔥 Trending Now — Cloud Native Intelligence <span class="trending-section__updated">Updated Jun 20, 2026</span></div>

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -34,7 +34,8 @@ theme:
     # standard vertical list and stays populated on every page incl. home.
     - navigation.top
     - navigation.tracking
-    - navigation.sections
+    # navigation.sections disabled: render top-level as COLLAPSIBLE nested
+    # sections (chevron + indentation) instead of flat group labels.
     # navigation.expand intentionally disabled: with ~169 nav entries it forced
     # every section open (heavy DOM, overwhelming). The Topic Map page now serves
     # as the full directory; the left nav stays collapsed and scannable.
@@ -51,7 +52,8 @@ theme:
     - content.action.view
     - content.action.edit
     - content.tooltips
-    - navigation.prune
+    # navigation.prune disabled: keep all children in the HTML so any section
+    # can expand (prune removed inactive children, leaving a flat list).
     # toc.integrate removed: show the native sticky "On this page" TOC in the
     # right sidebar instead of merging headings into the left nav. This replaces
     # the per-page Markdown "## Table of Contents" we no longer render.


### PR DESCRIPTION
Follow-up to the tabs removal (v2.9.25), fixing two things the user spotted.

## 1. Left nav was flat (no expand/indent)
After disabling tabs, the 18 sections rendered as a **flat list of labels** with no nesting — because `navigation.sections` makes them non-collapsible group labels and `navigation.prune` stripped inactive children. Disabled both → the left sidebar is now a proper **collapsible, nested, indented tree** (14 toggles / chevrons, collapsed by default, click to expand). No size penalty (88213 vs 88516 bytes).

## 2. Home now has real section headings
The home had a single H2, so its right-hand "On this page" TOC was empty. Added **`## Explore the Ecosystem`** (badge cards) and **`## Trending Now`** (digest) alongside the existing **`## The Cloud Native Universe We Track`** — verified the home's right TOC now lists all three.

## On the "are we losing the two-column quality?" concern
The opposite — both columns improve:
- **Content pages** (kubernetes, …): right TOC unchanged (already rich); left nav now shows the **full collapsible directory** instead of just the active section.
- **Home**: left nav now populated (was empty); right TOC now has 3 entries (was empty).

The only thing lost is the top tab-bar aesthetic.

## Validation
Built locally: 14 collapsible toggles + nested nav on the home; right TOC = `[explore-the-ecosystem, trending-now, the-cloud-native-universe-we-track]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)