### PR TITLE
feat(v2/nav): slim quick-nav bar with persistent key destinations

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -5,6 +5,25 @@
 {% endblock %}
 
 {#-
+  Slim quick-nav bar rendered below the header on every page (via the `tabs`
+  block, which is empty here since navigation.tabs is disabled). Gives the key
+  cross-cutting destinations a persistent, one-click home — without the
+  18-tab overflow and without collapsing the full left navigation tree.
+-#}
+{% block tabs %}
+<nav class="nb-quicknav" aria-label="Quick navigation">
+  <div class="nb-quicknav__inner">
+    <a class="nb-quicknav__link" href="/topic-map/">🗺️ Topic Map</a>
+    <a class="nb-quicknav__link" href="/tech-digest/">📊 Intelligence Digest</a>
+    <a class="nb-quicknav__link" href="/videos/">🎥 Video Hub</a>
+    <a class="nb-quicknav__link" href="/ai-agents-mcp/">🤖 AI &amp; MCP</a>
+    <a class="nb-quicknav__link" href="/methodology/">📐 Methodology</a>
+    <a class="nb-quicknav__link nb-quicknav__link--muted" href="/v1/">📚 V1 Archive</a>
+  </div>
+</nav>
+{% endblock %}
+
+{#-
   JSON-LD structured data (schema.org) for richer search results: declares the
   WebSite (with a sitelinks SearchAction) and the publishing Organization.
   Only the V2 portal uses this overrides dir (custom_dir: docs/overrides), so

--- a/docs/static/v2_elite.css
+++ b/docs/static/v2_elite.css
@@ -1230,6 +1230,50 @@ input[type="text"] {
   margin-top: 0;
   font-size: 1.05rem;
 }
+
+/* ===================================================================
+   Slim quick-nav bar (rendered in the theme `tabs` block, below header)
+   Persistent one-click access to key destinations on every page.
+   =================================================================== */
+.nb-quicknav {
+  background: var(--md-header-bg-color);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+.nb-quicknav__inner {
+  max-width: 1600px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 1.4rem;
+  flex-wrap: wrap;
+  padding: 0.4rem 1.2rem;
+}
+.nb-quicknav__link {
+  color: rgba(255, 255, 255, 0.78) !important;
+  text-decoration: none;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  transition: color 0.2s ease, text-shadow 0.2s ease;
+}
+.nb-quicknav__link:hover {
+  color: var(--md-accent-fg-color) !important;
+  text-shadow: 0 0 8px rgba(34, 211, 238, 0.35);
+}
+.nb-quicknav__link--muted {
+  opacity: 0.65;
+  margin-left: auto; /* push V1 Archive to the right edge */
+}
+/* On phones the left drawer already exposes navigation; let the bar scroll. */
+@media screen and (max-width: 44.9375em) {
+  .nb-quicknav__inner {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    gap: 1rem;
+  }
+  .nb-quicknav__link--muted { margin-left: 1rem; }
+}
 .topic-map-dim ul {
   margin-top: 0.3rem;
 }

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -114,7 +114,7 @@ extra:
 extra_css:
   - https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap
   - static/extra.css
-  - static/v2_elite.css?v=2.9.17
+  - static/v2_elite.css?v=2.9.27
 
 extra_javascript:
   - static/v2_filter.js?v=2.9.19


### PR DESCRIPTION
A thin horizontal bar below the header, on **every** page, with 6 curated one-click destinations:

🗺️ Topic Map · 📊 Intelligence Digest · 🎥 Video Hub · 🤖 AI & MCP · 📐 Methodology · 📚 V1 Archive

## Why
The key cross-cutting destinations previously only existed as **badge cards on the home**. Deep in a category page, reaching the Digest/Topic Map meant hunting the left tree. This bar gives them a **persistent, one-click home** on every page.

## How
Overrides Material's `tabs` block (empty since `navigation.tabs` is disabled) + a `.nb-quicknav` style. So it does NOT bring back the 18-tab overflow and does NOT collapse the full left navigation tree — it coexists with both. Template/CSS only (no page regeneration); V2-only (V1 uses the stock theme).

## Validation
Built locally: the bar renders on both the home and content pages (kubernetes), with `0` Material tabs; all 6 links resolve to absolute root paths that work from any depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)