### PR TITLE
fix(v2): bump v2_elite.css cache-buster (Show more was broken on live site)

### DIFF
--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -115,7 +115,7 @@ extra:
 extra_css:
   - https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap
   - static/extra.css
-  - static/v2_elite.css?v=2.9.42
+  - static/v2_elite.css?v=2.9.46
 
 extra_javascript:
   - static/v2_filter.js?v=2.9.19


### PR DESCRIPTION
## Bug
The `▼ Show more` / `▲ Show less` disclosure on the Trending lanes (shipped in v2.9.45) did nothing on the **live site**, and both labels showed at once.

## Root cause
`v2-mkdocs.yml` pinned `extra_css: static/v2_elite.css?v=2.9.42` and it was **never bumped**. Returning visitors kept the cached v2.9.42 stylesheet, which predates the disclosure rules (`.trending-card--extra`, `.trending-showmore`, the `:checked ~` toggle). So:
- no rule hid the overflow cards or the inactive label span → both "Show N more" and "Show less" rendered together;
- no `:checked` rule → clicking the label did nothing.

The CSS *file content* on master was correct (the publisher synced it); only the cache-busting URL was stale.

## Fix
Bump `?v=2.9.42` → `?v=2.9.46` so the URL changes and browsers/CDN re-fetch.

## Verification
Built the real site (`mkdocs build -f v2-mkdocs.yml`) and drove `index.html` with Playwright in a real Material DOM: lane 1 goes **9 → 16** cards on click, label flips `▼ Show 7 more` → `▲ Show less`, only one label visible at a time. Confirmed `index.html` now emits `?v=2.9.46`.

## Follow-up (not in this PR)
This cache-buster is bumped by hand and silently drifted across 2.9.43–2.9.45. Worth tying it to the release version automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)