### PR TITLE
feat(v2): auto-version static assets from release tag (no more manual ?v=)

### DIFF
--- a/scripts/mkdocs_hooks.py
+++ b/scripts/mkdocs_hooks.py
@@ -1,0 +1,57 @@
+"""MkDocs build hooks for the Nubenetes V2 portal.
+
+Auto-versions cache-busted static assets so a CSS/JS change never goes stale
+behind a hand-maintained `?v=` query string again (see v2.9.45 regression where
+the Trending "Show more" disclosure was invisible to returning visitors because
+`?v=` was pinned to 2.9.42).
+
+The version is resolved from, in order:
+  1. $SITE_VERSION  (set explicitly by the deploy workflow)
+  2. the latest git tag (`git describe --tags --abbrev=0`)
+If neither is available (e.g. a local `mkdocs serve` in a shallow checkout),
+the asset URLs are left untouched so the build never fails.
+"""
+import os
+import subprocess
+
+# Static assets whose URL should carry the release version as a cache-buster.
+_VERSIONED_ASSETS = ("v2_elite.css", "v2_filter.js")
+
+
+def _resolve_version():
+    v = os.environ.get("SITE_VERSION", "").strip()
+    if not v:
+        try:
+            v = subprocess.check_output(
+                ["git", "describe", "--tags", "--abbrev=0"],
+                stderr=subprocess.DEVNULL,
+            ).decode().strip()
+        except Exception:
+            return None
+    return v.lstrip("v") or None
+
+
+def _bump(items, version):
+    out = []
+    for item in items:
+        # extra_javascript entries may be plain strings or ExtraScript objects.
+        path = item if isinstance(item, str) else getattr(item, "path", None)
+        if path and any(name in path for name in _VERSIONED_ASSETS):
+            new_path = f"{path.split('?')[0]}?v={version}"
+            if isinstance(item, str):
+                out.append(new_path)
+            else:
+                item.path = new_path
+                out.append(item)
+        else:
+            out.append(item)
+    return out
+
+
+def on_config(config, **kwargs):
+    version = _resolve_version()
+    if not version:
+        return config
+    config["extra_css"] = _bump(config.get("extra_css", []), version)
+    config["extra_javascript"] = _bump(config.get("extra_javascript", []), version)
+    return config

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -60,6 +60,11 @@ theme:
     # the per-page Markdown "## Table of Contents" we no longer render.
     - toc.follow
 
+# Auto-version cache-busted static assets (v2_elite.css / v2_filter.js) from the
+# release tag, so a CSS/JS change never goes stale behind a hand-maintained ?v=.
+hooks:
+  - scripts/mkdocs_hooks.py
+
 plugins:
   - search
   # "Last updated" per-page date (freshness signal for SEO + reader trust).
@@ -115,10 +120,12 @@ extra:
 extra_css:
   - https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap
   - static/extra.css
-  - static/v2_elite.css?v=2.9.46
+  # ?v= cache-buster is appended automatically from the release tag by
+  # scripts/mkdocs_hooks.py — do not hand-maintain it here.
+  - static/v2_elite.css
 
 extra_javascript:
-  - static/v2_filter.js?v=2.9.19
+  - static/v2_filter.js
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Why
Follow-up to v2.9.46. The `?v=` cache-buster on V2 static assets was hand-maintained in `v2-mkdocs.yml` and silently drifted — `v2_elite.css` was stuck at `?v=2.9.42` (broke the Trending "Show more" disclosure for returning visitors) and `v2_filter.js` at `?v=2.9.19`. Forgetting to bump it = the change is invisible live.

## What
- New MkDocs `on_config` hook `scripts/mkdocs_hooks.py` appends the release version as the `?v=` cache-buster on `v2_elite.css` and `v2_filter.js`.
- Version resolved from `$SITE_VERSION`, else the latest git tag (`git describe --tags --abbrev=0`); leaves URLs untouched if neither is available so local `mkdocs serve` / shallow checkouts never break.
- Handles both string and `ExtraScript`-object `extra_javascript` entries.
- Removed the hand-maintained query strings from `v2-mkdocs.yml`.

## Verification
- `mkdocs build` from the git tag → `v2_elite.css?v=2.9.46` and `v2_filter.js?v=2.9.46`.
- `SITE_VERSION=9.9.9 mkdocs build` → `?v=9.9.9` on both.
- Build exits 0 in both cases.

## Deploy note
The deploy (06.1) checks out with `fetch-depth: 0` (tags included), so `git describe` resolves the latest tag at build time. Release flow should **push the tag before the master branch** so the tag exists when the deploy job checks out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)