### PR TITLE
fix: invert Nutanix logo in dark mode (V2 mosaic)

### DIFF
--- a/docs/static/v2_elite.css
+++ b/docs/static/v2_elite.css
@@ -334,6 +334,14 @@ a {
   border-radius: 4px;
 }
 
+/* Dark-logo fix: invert black-on-transparent logos so they remain visible in dark mode */
+[data-md-color-scheme="slate"] img[src*="nutanix_logo"] {
+  filter: invert(1);
+}
+[data-md-color-scheme="slate"] img[src*="nutanix_logo"]:hover {
+  filter: invert(1) brightness(1.25);
+}
+
 /* V2 Homepage Hero Dashboard Cards */
 .hero-badge-card {
   flex: 1;


### PR DESCRIPTION
## Summary

The Nutanix logo (`nutanix_logo.png`) is black-on-transparent, making it invisible in V2 dark mode (`[data-md-color-scheme="slate"]`).

**Fix:** targeted CSS `filter: invert(1)` applied only in dark mode — no image modification needed.

- Light mode: unchanged (black X on transparent ✓)
- Dark mode: inverted to white X on transparent ✓
- Hover in dark mode: invert + brightness combined ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)