### PR TITLE
fix: invert Nutanix logo in dark mode for V1 mosaic

### DIFF
--- a/docs/static/extra.css
+++ b/docs/static/extra.css
@@ -49,6 +49,14 @@ reset max-width with the following CSS: */
   filter: brightness(1.2);
 }
 
+/* Dark-logo fix: invert black-on-transparent logos so they remain visible in dark mode */
+[data-md-color-scheme="slate"] img[src*="nutanix_logo"] {
+  filter: invert(1);
+}
+[data-md-color-scheme="slate"] img[src*="nutanix_logo"]:hover {
+  filter: invert(1) brightness(1.2);
+}
+
 
 
 


### PR DESCRIPTION
## Summary

Same fix as v2.9.53 applied to V1. The Nutanix logo (black-on-transparent PNG) is invisible in dark mode.

Adds targeted CSS to `docs/static/extra.css` (V1 stylesheet):
- `[data-md-color-scheme="slate"] img[src*="nutanix_logo"] { filter: invert(1); }`
- Hover state: `filter: invert(1) brightness(1.2)`

Light mode: unchanged ✓  Dark mode: white logo visible ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)