### PR TITLE
Release v2.9.58 — flagship Awesome Lists page (hero + category grid)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Additionally, as of May 2026, Nubenetes has reached the **Platinum Operational T
 | :--- | :--- |
 | **Total Technical Resources (Links)** | **18657+** |
 | **Specialized MD Pages** | **162** |
-| **Total Commits** | **6512+** |
+| **Total Commits** | **6514+** |
 | **Primary AI Engine** | **Google Gemini (Agentic)** |
 <!-- HEART_STATS_END -->
 
@@ -180,7 +180,7 @@ The growth of Nubenetes reflects the acceleration of the Cloud Native ecosystem.
 | 6 | 2023 | 30 | 123 | Maintenance & Refinement |
 | 7 | 2024 | 53 | 218 | Curation Strategy Pivot |
 | 8 | 2025 | 5 | 20 | Stability & Research Phase |
-| 9 | 2026 | 2953 | 12,195 | **Agentic AI Surge** (May 2026 Inception) |
+| 9 | 2026 | 2955 | 12,204 | **Agentic AI Surge** (May 2026 Inception) |
 <!-- ANNUAL_GROWTH_END -->
 
 <!-- ANNUAL_CHART_START -->
@@ -196,8 +196,8 @@ xychart-beta
     title "Nubenetes Annual Growth Metrics (2018–2026)"
     x-axis ["2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025", "2026"]
     y-axis "Volume (Commits / Estimated New Refs)" 0 --> 13000
-    bar [1445, 586, 8449, 2193, 1660, 123, 218, 20, 12195]
-    bar [350, 142, 2046, 531, 402, 30, 53, 5, 2953]
+    bar [1445, 586, 8449, 2193, 1660, 123, 218, 20, 12204]
+    bar [350, 142, 2046, 531, 402, 30, 53, 5, 2955]
 ```
 <!-- ANNUAL_CHART_END -->
 
@@ -207,7 +207,7 @@ xychart-beta
 | :--- | :---: | :---: | :--- |
 | 2026-04 | 25 | 103 | Active Curation |
 | 2026-05 | 2101 | 8,677 | **Agentic Inception (Gemini Era)** |
-| 2026-06 | 827 | 3,415 | Active Curation |
+| 2026-06 | 829 | 3,423 | Active Curation |
 <!-- MONTHLY_SURGE_END -->
 
 ### 2.4. Content Distribution and Semantic Clustering

--- a/docs/static/v2_elite.css
+++ b/docs/static/v2_elite.css
@@ -1804,3 +1804,108 @@ input[type="text"] {
 
 
 
+
+/* ===================================================================
+   The Awesome Lists page: high-impact hero + category card grid.
+   Used by other-awesome-lists.md (header injected by src/awesome_page.py).
+   =================================================================== */
+.awesome-hero {
+  margin: 1.2rem 0 1.6rem;
+  padding: 2.2rem 1.5rem;
+  border-radius: 16px;
+  text-align: center;
+  color: #fff;
+  background:
+    radial-gradient(120% 140% at 50% 0%,
+      color-mix(in srgb, var(--md-accent-fg-color) 70%, #6d28d9) 0%,
+      color-mix(in srgb, var(--md-primary-fg-color) 80%, #111827) 75%);
+  box-shadow: 0 10px 34px -12px color-mix(in srgb, var(--md-accent-fg-color) 60%, transparent);
+  overflow: hidden;
+}
+.awesome-hero__badge {
+  font-size: clamp(1.4rem, 3.2vw, 2.2rem);
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  line-height: 1.15;
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.28);
+}
+.awesome-hero__sub {
+  margin-top: 0.5rem;
+  font-size: 0.95rem;
+  opacity: 0.92;
+}
+.awesome-hero__sub code {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  padding: 0.05em 0.35em;
+  border-radius: 5px;
+}
+.awesome-hero__stats {
+  margin-top: 1.3rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.7rem 1.4rem;
+}
+.awesome-hero__stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.9;
+}
+.awesome-hero__stat strong {
+  font-size: 1.55rem;
+  line-height: 1;
+  font-weight: 800;
+}
+
+.awesome-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  gap: 0.85rem;
+  margin: 1.4rem 0 2rem;
+}
+.awesome-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 0.6rem;
+  min-height: 84px;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 24%, transparent);
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  text-decoration: none;
+  transition: transform 0.14s ease, box-shadow 0.14s ease, border-color 0.14s ease;
+}
+.awesome-card:hover {
+  transform: translateY(-3px);
+  border-color: var(--md-accent-fg-color);
+  box-shadow: 0 12px 26px -14px color-mix(in srgb, var(--md-accent-fg-color) 70%, transparent);
+}
+.awesome-card__name {
+  font-weight: 700;
+  font-size: 0.95rem;
+  line-height: 1.25;
+}
+.awesome-card__meta {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+}
+.awesome-card__count {
+  font-size: 1.35rem;
+  font-weight: 800;
+  color: var(--md-accent-fg-color);
+  line-height: 1;
+}
+.awesome-card__stars {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.7;
+}

--- a/src/awesome_page.py
+++ b/src/awesome_page.py
@@ -1,0 +1,74 @@
+"""High-impact header for the V2 "Awesome Lists" page.
+
+The Awesome Lists page (``other-awesome-lists.md``, derived from V1's
+``/v1/other-awesome-lists/``) is a curated, AI-classified directory of the best
+external ``awesome-*`` lists across the Cloud Native ecosystem. This module
+builds the flagship hero banner + a category grid (cards that jump to each
+in-page section), generated from the page's own rendered ``##`` headings so it
+stays in sync no matter how the AI re-clusters the categories.
+
+Pure stdlib so it can run inside ``src.v2_optimizer`` and be tested standalone.
+"""
+
+import re
+
+_H2_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+_LINK_RE = re.compile(r"\]\(https?://")
+
+
+def _slug(text: str) -> str:
+    """Slug matching python-markdown/toc anchors (lowercase, no punctuation)."""
+    s = text.lower().replace("&", " ")
+    s = re.sub(r"[()]", "", s)
+    s = re.sub(r"[^a-z0-9]+", "-", s).strip("-")
+    return s
+
+
+def _sections(body_md: str):
+    """Return [(title, anchor, link_count), ...] for each H2 section in order."""
+    matches = list(_H2_RE.finditer(body_md))
+    out = []
+    for i, m in enumerate(matches):
+        title = m.group(1).strip()
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(body_md)
+        count = len(_LINK_RE.findall(body_md[start:end]))
+        out.append((title, _slug(title), count))
+    return out
+
+
+def build_awesome_lists_header(body_md: str) -> str:
+    """Build the hero + category grid that precedes the Awesome Lists body."""
+    sections = _sections(body_md)
+    total_lists = sum(c for _, _, c in sections)
+    n_cats = len(sections)
+
+    md = (
+        "<div class=\"awesome-hero\">\n"
+        "  <div class=\"awesome-hero__badge\">⭐ AWESOME LISTS ⭐</div>\n"
+        "  <div class=\"awesome-hero__sub\">The best curated <code>awesome-*</code> lists · AI-classified · link-validated</div>\n"
+        "  <div class=\"awesome-hero__stats\">\n"
+        f"    <span class=\"awesome-hero__stat\"><strong>{total_lists}</strong>curated lists</span>\n"
+        f"    <span class=\"awesome-hero__stat\"><strong>{n_cats}</strong>categories</span>\n"
+        "  </div>\n"
+        "</div>\n\n"
+        "!!! tip \"The meta-directory of the Cloud Native ecosystem\"\n"
+        "    A hand-picked, AI-classified index of the most valuable community "
+        "**awesome-* lists** — every one link-validated and filed by topic. Jump "
+        "to a category below, or browse the full directory. For the original "
+        "exhaustive archive, see the [**V1 Historical Archive**](/v1/other-awesome-lists/).\n\n"
+    )
+
+    if sections:
+        md += "<div class=\"awesome-grid\">\n"
+        for title, anchor, count in sections:
+            md += (
+                f"  <a class=\"awesome-card\" href=\"#{anchor}\">\n"
+                f"    <span class=\"awesome-card__name\">{title}</span>\n"
+                f"    <span class=\"awesome-card__meta\"><span class=\"awesome-card__count\">{count}</span>"
+                f"<span class=\"awesome-card__stars\">lists</span></span>\n"
+                f"  </a>\n"
+            )
+        md += "</div>\n\n"
+
+    return md

--- a/src/v2_optimizer.py
+++ b/src/v2_optimizer.py
@@ -16,6 +16,7 @@ from src.config import GEMINI_API_KEYS, GH_TOKEN, TARGET_REPO, MADRID_TZ, INVENT
 from src.gemini_utils import call_gemini_with_retry, normalize_url, clean_toc_text, get_github_activity, fetch_youtube_metadata
 from src.logger import log_event
 from src.inventory_manager import update_inventory_entry
+from src.awesome_page import build_awesome_lists_header
 
 
 def nuclear_strip(text: str) -> str:
@@ -1724,8 +1725,16 @@ class V2VisionEngine:
                 )
 
 
-            md += await render_node(info["content"], -1, f_name.replace(".md", ""), used_headers, is_intro=(f_name=="introduction.md" or f_name=="about.md"))
-            
+            _body = await render_node(info["content"], -1, f_name.replace(".md", ""), used_headers, is_intro=(f_name=="introduction.md" or f_name=="about.md"))
+            # The flagship "Awesome Lists" page gets a high-impact hero + a grid
+            # of its categories (auto-derived from the rendered H2 sections).
+            if f_name == "other-awesome-lists.md":
+                try:
+                    md += build_awesome_lists_header(_body)
+                except Exception as e:
+                    log_event(f"[WARN] awesome-lists header failed: {str(e)[:100]}")
+            md += _body
+
             # Add Semantic "See Also" — same dimension + cross-dimension by shared tags
             same_dim = [f for f in data if f != f_name and data[f]["dim"] == info["dim"]]
             cross_dim = []

--- a/v2-docs/other-awesome-lists.md
+++ b/v2-docs/other-awesome-lists.md
@@ -9,6 +9,74 @@ description: "Top Other Awesome Lists resources for 2026, AI-ranked: Awesome Com
 !!! info "Architectural Context"
     Detailed reference for Awesome Lists in the context of Architectural Foundations.
 
+
+<div class="awesome-hero">
+  <div class="awesome-hero__badge">⭐ AWESOME LISTS ⭐</div>
+  <div class="awesome-hero__sub">The best curated <code>awesome-*</code> lists · AI-classified · link-validated</div>
+  <div class="awesome-hero__stats">
+    <span class="awesome-hero__stat"><strong>33</strong>curated lists</span>
+    <span class="awesome-hero__stat"><strong>13</strong>categories</span>
+  </div>
+</div>
+
+!!! tip "The meta-directory of the Cloud Native ecosystem"
+    A hand-picked, AI-classified index of the most valuable community **awesome-* lists** — every one link-validated and filed by topic. Jump to a category below, or browse the full directory. For the original exhaustive archive, see the [**V1 Historical Archive**](/v1/other-awesome-lists/).
+
+<div class="awesome-grid">
+  <a class="awesome-card" href="#ai-and-machine-learning">
+    <span class="awesome-card__name">AI and Machine Learning</span>
+    <span class="awesome-card__meta"><span class="awesome-card__count">1</span><span class="awesome-card__stars">lists</span></span>
+  </a>
+  <a class="awesome-card" href="#api-development">
+    <span class="awesome-card__name">API Development</span>
+    <span class="awesome-card__meta"><span class="awesome-card__count">2</span><span class="awesome-card__stars">lists</span></span>
+  </a>
+  <a class="awesome-card" href="#artificial-intelligence">
+    <span class="awesome-card__name">Artificial Intelligence</span>
+    <span class="awesome-card__meta"><span class="awesome-card__count">1</span><span class="awesome-card__stars">lists</span></span>
+  </a>
+  <a class="awesome-card" href="#cloud-native">
+    <span class="awesome-card__name">Cloud Native</span>
+    <span class="awesome-card__meta"><span class="awesome-card__count">10</span><span class="awesome-card__stars">lists</span></span>
+  </a>
+  <a class="awesome-card" href="#continuous-delivery">
+    <span class="awesome-card__name">Continuous Delivery</span>
+    <span class="awesome-card__meta"><span class="awesome-card__count">1</span><span class="awesome-card__stars">lists</span></span>
+  </a>
+  <a class="awesome-card" href="#curation">
+    <span class="awesome-card__name">Curation</span>
+    <span class="awesome-card__meta"><span class="awesome-card__count">3</span><span class="awesome-card__stars">lists</span></span>
+  </a>
+  <a class="awesome-card" href="#deployment-and-delivery">
+    <span class="awesome-card__name">Deployment and Delivery</span>
+    <span class="awesome-card__meta"><span class="awesome-card__count">1</span><span class="awesome-card__stars">lists</span></span>
+  </a>
+  <a class="awesome-card" href="#devops-and-platform-engineering">
+    <span class="awesome-card__name">DevOps and Platform Engineering</span>
+    <span class="awesome-card__meta"><span class="awesome-card__count">1</span><span class="awesome-card__stars">lists</span></span>
+  </a>
+  <a class="awesome-card" href="#infrastructure">
+    <span class="awesome-card__name">Infrastructure</span>
+    <span class="awesome-card__meta"><span class="awesome-card__count">1</span><span class="awesome-card__stars">lists</span></span>
+  </a>
+  <a class="awesome-card" href="#infrastructure-and-operations">
+    <span class="awesome-card__name">Infrastructure and Operations</span>
+    <span class="awesome-card__meta"><span class="awesome-card__count">5</span><span class="awesome-card__stars">lists</span></span>
+  </a>
+  <a class="awesome-card" href="#observability-and-monitoring">
+    <span class="awesome-card__name">Observability and Monitoring</span>
+    <span class="awesome-card__meta"><span class="awesome-card__count">1</span><span class="awesome-card__stars">lists</span></span>
+  </a>
+  <a class="awesome-card" href="#programming-languages">
+    <span class="awesome-card__name">Programming Languages</span>
+    <span class="awesome-card__meta"><span class="awesome-card__count">3</span><span class="awesome-card__stars">lists</span></span>
+  </a>
+  <a class="awesome-card" href="#software-engineering">
+    <span class="awesome-card__name">Software Engineering</span>
+    <span class="awesome-card__meta"><span class="awesome-card__count">3</span><span class="awesome-card__stars">lists</span></span>
+  </a>
+</div>
+
 ## AI and Machine Learning
 
 ### MLOps

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -162,6 +162,7 @@ markdown_extensions:
 nav:
   - "🔙 Back to V1 (Exhaustive)": https://nubenetes.com/v1/
   - "The 2026 Vision": index.md
+  - "⭐ Awesome Lists": other-awesome-lists.md
   - "Portal Guide":
     - "Topic Map": topic-map.md
     - "Methodology": methodology.md
@@ -200,7 +201,6 @@ nav:
     - "Matrix Table": matrix-table.md
     - "Mkdocs": mkdocs.md
     - "Monitoring": monitoring.md
-    - "Other Awesome Lists": other-awesome-lists.md
     - "Prometheus": prometheus.md
   - "Platform & Site Reliability":
     - "Chaos Engineering": chaos-engineering.md


### PR DESCRIPTION
## Summary
Promotes the V2 **Awesome Lists** page (`other-awesome-lists.md`, derived from V1's `/v1/other-awesome-lists/`) from a buried submenu item to a flagship, high-impact destination.

### Changes
- **`src/awesome_page.py`** (new): builds a hero banner + a category card grid, auto-derived from the page's own rendered H2 sections (so it stays in sync with AI re-clustering).
- **`src/v2_optimizer.py`**: injects the header for `other-awesome-lists.md` during rendering — survives pipeline regeneration.
- **Nav**: new top-level **"⭐ Awesome Lists"** entry; removed the duplicate under "Architectural Foundations".
- **CSS**: hero/grid/card styles added to the V2 stylesheet.
- Applied the header to the current rendered page for immediate deploy (33 curated lists, 13 categories).

Name kept as **"Awesome Lists"** (consistent with V1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)