### PR TITLE
Release v2.9.60 — Awesome Lists in Portal Guide quick-nav

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -18,7 +18,7 @@
   IaC in IaC; Docker in Kubernetes; …). AWS is a NESTED submenu inside Cloud,
   OpenShift a NESTED submenu inside Kubernetes.
   Pages may appear in more than one menu when that aids discovery.
-    Portal Guide (Topic Map · Methodology · Tags · About) · Digest · Videos
+    Portal Guide (Topic Map · Awesome Lists · Methodology · Tags · About) · Digest · Videos
     · Kubernetes (+Docker, OpenShift▸) · Delivery (CI/CD·GitOps·DevOps) · IaC
     · Cloud (AWS▸ · Azure · GCP · …) · Network · Security · Observability & SRE
     · AI & Data · Dev & Platform · More
@@ -30,6 +30,7 @@
       <button class="nb-quicknav__link nb-quicknav__btn" popovertarget="nb-pop-guide" type="button">🧭 Portal Guide <span class="nb-quicknav__caret" aria-hidden="true">▾</span></button>
       <div class="nb-quicknav__menu" id="nb-pop-guide" popover>
         <a href="/topic-map/">🗺️ Topic Map</a>
+        <a href="/other-awesome-lists/">⭐ Awesome Lists</a>
         <a href="/methodology/">📐 Methodology</a>
         <a href="/tags/">🏷️ Technical Tags</a>
         <a href="/about/">ℹ️ About</a>

--- a/src/v2_optimizer.py
+++ b/src/v2_optimizer.py
@@ -2010,12 +2010,16 @@ class V2VisionEngine:
                 "nav:",
                 "  - \"🔙 Back to V1 (Exhaustive)\": https://nubenetes.com/v1/",
                 "  - \"The 2026 Vision\": index.md",
+                # Flagship: the curated Awesome Lists directory, promoted to a
+                # prominent top-level entry (also surfaced in Portal Guide below).
+                "  - \"⭐ Awesome Lists\": other-awesome-lists.md",
                 # Portal Guide: collapsible hub for the site-orientation / meta
                 # pages — the topic directory, how the portal is curated, the tag
-                # index and the project About. about.md is pulled out of its
-                # Architectural Foundations dimension here (see _FIXED_PAGES below).
+                # index and the project About. about.md and other-awesome-lists.md
+                # are pulled out of their dimension here (see _FIXED_PAGES below).
                 "  - \"Portal Guide\":",
                 "    - \"Topic Map\": topic-map.md",
+                "    - \"Awesome Lists\": other-awesome-lists.md",
                 "    - \"Methodology\": methodology.md",
                 "    - \"Technical Tags\": tags.md",
                 "    - \"About\": about.md",
@@ -2034,7 +2038,7 @@ class V2VisionEngine:
 
             # Topic pages promoted into a fixed header group above; skip them in
             # the dimension loop so they are not also listed under their dimension.
-            _FIXED_PAGES = {"about.md"}
+            _FIXED_PAGES = {"about.md", "other-awesome-lists.md"}
 
             dim_groups = {}
             for f_name, info in data.items():


### PR DESCRIPTION
## Summary
Fix: the top horizontal bar is a **custom quick-nav** (`docs/overrides/main.html`), not Material's tab bar (`navigation.tabs` is disabled). Its **Portal Guide** popover was hardcoded and didn't include Awesome Lists — so the earlier sidebar-nav change wasn't visible there.

### Changes
- Add **⭐ Awesome Lists** to the Portal Guide quick-nav popover (after Topic Map).
- Make the sidebar nav durable: add the top-level entry + Portal Guide child in `_sync_enterprise_navigation`, and exclude `other-awesome-lists.md` from its dimension via `_FIXED_PAGES`, so a full pipeline run no longer wipes these entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)