### PR TITLE
fix(ci): install missing core python dependencies in weekly digest workflow

### DIFF
--- a/.github/workflows/09.weekly_digest.yml
+++ b/.github/workflows/09.weekly_digest.yml
@@ -31,7 +31,10 @@ jobs:
           cache: 'pip'
 
       - name: Install Dependencies
-        run: pip install -r requirements.txt
+        run: |
+          python -m pip install --upgrade pip
+          pip install --no-cache-dir pydantic PyGithub httpx fake-useragent pytz python-dotenv pyyaml tenacity
+          pip install -r requirements.txt
 
       - name: Generate News Digest (Incremental)
         env:


### PR DESCRIPTION
Fixes the ModuleNotFoundError: No module named 'httpx' failure in 09. Weekly Intelligence Digest run 28366836985 by installing core dependencies first.