### PR TITLE
Add Doubleword Control Layer Helm chart to Helm Charts

### DIFF
--- a/docs/helm.md
+++ b/docs/helm.md
@@ -199,6 +199,7 @@ Kubernetes packages
 - [prometheus-community.github.io: Prometheus Community Kubernetes Helm Charts 🌟](https://prometheus-community.github.io/helm-charts)
 - [boxunix.com: Developer’s Guide to Writing a Good Helm Chart](https://boxunix.com/2022/02/05/developers-guide-to-writing-a-good-helm-chart)
 - [HULL](https://github.com/vidispine/hull) The incredible HULL - Helm Uniform Layer Library - is a Helm library chart to improve Helm chart based workflows
+- [Doubleword Control Layer](https://github.com/doublewordai/control-layer-chart) Helm chart (Helm 3, installable from an OCI registry) for deploying the Doubleword Control Layer on Kubernetes, including the Deployment, Service, ConfigMap, database Secret, and an optional Prometheus ServiceMonitor. The Control Layer is an open-source, Rust-based AI model gateway (450x less overhead than LiteLLM) that provides unified access to LLMs across providers behind a single authentication layer, with API key generation, user management, and request logging.
 
 ## Shalm. Scriptable helm charts
 


### PR DESCRIPTION
### Description of Changes

Adds one entry to the **Helm Charts** section of `docs/helm.md`:

- **Doubleword Control Layer** ([control-layer-chart](https://github.com/doublewordai/control-layer-chart)) — a Helm 3 chart (installable from an OCI registry) that deploys the Doubleword Control Layer on Kubernetes: Deployment, Service, ConfigMap, database Secret, and an optional Prometheus ServiceMonitor. The Control Layer itself is an open-source, Rust-based AI model gateway (450x less overhead than LiteLLM) providing unified access to LLMs across providers behind a single auth layer, with API key generation, user management, and request logging.

This fits the existing **Helm Charts** list of deployable charts and adds cloud-native AI-gateway coverage to the archive.

### Checklist

- [x] **High-Density Technical Description**: The description covers the chart's rendered resources plus the gateway's architecture and key features (no generic clickbait).
- [x] **No Emojis in Titles**: No headers were added or changed.
- [x] **URL Normalization**: Plain GitHub URL, no UTM/tracker parameters.
- [x] **Active Project**: Both the chart and gateway repositories have recent commits.
- [x] **Valid Markdown**: Single list item matching the neighbouring entry format; no HTML added.
