### PR TITLE
Add nodejs-k8s to non-production local Kubernetes installers

### DIFF
--- a/docs/kubernetes-based-devel.md
+++ b/docs/kubernetes-based-devel.md
@@ -49,6 +49,7 @@
 - [Metal Kubes](https://github.com/shank-git/metal-kubes) Create OnPrem Kubernetes Cluster. Install Kubernetes Cluster on Bare Metal Machines
 - [blog.flant.com: Small Kubernetes for your local experiments: k0s, MicroK8s, kind, k3s, and Minikube](https://palark.com/blog/small-local-kubernetes-comparison)
 - [dj-wasabi/vagrant-kubernetes](https://github.com/dj-wasabi/vagrant-kubernetes) Playground for setting up small Kubernetes cluster on some **vagrant** boxes and practice with various examples to get familiar with K8s.
+- [nodejs-k8s](https://github.com/Megapixel99/nodejs-k8s) A reimplementation of the core Kubernetes APIs (pods, deployments, replica sets, services, jobs, namespaces and configmaps) in Node.js, serving the same HTTP/JSON and protobuf surface as a real kube-apiserver so that an unmodified **kubectl** talks to it directly with standard Kubernetes YAML. Objects are persisted in MongoDB instead of etcd, with writes ordered through a Raft log behind an etcd-compatible store, and pods are run as sibling Docker containers. Useful as a lightweight API server for learning kubectl and for exercising operators and controllers without provisioning a cluster.
 
 ## Kubernetes Based Development. Kubernetes Development Tools
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] **High-Density Technical Description**: The entry states the API surface served, the storage and consensus model, how pods are executed, and what the project is useful for.
- [x] **No Emojis in Titles**: No headers were added or changed.
- [x] **URL Normalization**: The single URL is a plain GitHub repository link with no tracking parameters.
- [x] **Active Project**: The repository was last pushed to on 21 Aug 2026.
- [x] **Valid Markdown**: The change is one list item matching the surrounding entries; no HTML is involved.

### Description of Changes

Adds nodejs-k8s to `docs/kubernetes-based-devel.md`, under **Non-production Kubernetes Local Installers**.

nodejs-k8s reimplements the core Kubernetes APIs (pods, deployments, replica sets, services, jobs, namespaces and configmaps) in Node.js, over the same HTTP/JSON and protobuf surface that a real kube-apiserver exposes, so an unmodified `kubectl` talks to it directly with standard Kubernetes YAML. Objects are persisted in MongoDB rather than etcd (writes are ordered through a Raft log behind an etcd-compatible store), and pods are run as sibling Docker containers.

The section already collects minikube, kind and k3s, which provision real clusters locally; this one is the lighter case of wanting the API server alone, for learning kubectl or for exercising operators and controllers without a cluster to run them against.

Repository: https://github.com/Megapixel99/nodejs-k8s

### Nubenetes PR Guardian
